### PR TITLE
docs: emit data_arch observer events for duplicated domain types and transport dto leaks

### DIFF
--- a/.jules/exchange/events/duplicate_final_result_type_data_arch.md
+++ b/.jules/exchange/events/duplicate_final_result_type_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-20"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The result of the action execution is modeled twice: once as `FinalResult` in the domain logic, and once as `RetryActionOutput` in the action output logic. Furthermore, the `'success' | 'error' | 'timeout'` union type is hardcoded in `RetryActionOutput` rather than reusing the domain's `AttemptOutcome`.
+
+## Goal
+
+Eliminate `RetryActionOutput` and have `emitOutputs` consume `FinalResult` directly, or explicitly map the domain `FinalResult` to an output DTO without redeclaring structural types.
+
+## Context
+
+The `FinalResult` and `RetryActionOutput` interfaces define the exact same data structure. Due to TypeScript's structural typing, `FinalResult` is being implicitly passed to `emitOutputs(result: RetryActionOutput)` in `src/index.ts`. This is a transport DTO leaking into core domain logic (or vice versa) as an identical duplicate, violating Single Source of Truth and risking divergence.
+
+## Evidence
+
+- path: "src/domain/result.ts"
+  loc: "lines 9-14"
+  note: "Defines `FinalResult`."
+- path: "src/action/emit-outputs.ts"
+  loc: "lines 3-8"
+  note: "Defines `RetryActionOutput` which structurally duplicates `FinalResult`, including a hardcoded inline union for `finalOutcome` instead of reusing `AttemptOutcome`."
+- path: "src/index.ts"
+  loc: "line 9"
+  note: "Passes `result` of type `FinalResult` implicitly as `RetryActionOutput` to `emitOutputs`."
+
+## Change Scope
+
+- `src/domain/result.ts`
+- `src/action/emit-outputs.ts`
+- `src/index.ts`

--- a/.jules/exchange/events/duplicate_retry_on_type_data_arch.md
+++ b/.jules/exchange/events/duplicate_retry_on_type_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-20"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The `RetryOn` concept is defined multiple times as a string union type (`'any' | 'error' | 'timeout'`) without a single source of truth.
+
+## Goal
+
+Unify the `RetryOn` definition so there is a single source of truth used across the domain and transport boundaries.
+
+## Context
+
+Following the Single Source of Truth principle, each fact or concept should have one canonical representation. Currently, the type is duplicated between the transport/DTO layer (`read-inputs.ts`) and the domain layer (`policy.ts`), which requires synchronization if new retry states are added.
+
+## Evidence
+
+- path: "src/domain/policy.ts"
+  loc: "line 2"
+  note: "Defines `export type RetryOn = 'any' | 'error' | 'timeout'`."
+- path: "src/action/read-inputs.ts"
+  loc: "line 3"
+  note: "Duplicates the definition of `export type RetryOn = 'any' | 'error' | 'timeout'`."
+
+## Change Scope
+
+- `src/domain/policy.ts`
+- `src/action/read-inputs.ts`

--- a/.jules/exchange/events/transport_dto_leak_data_arch.md
+++ b/.jules/exchange/events/transport_dto_leak_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-20"
+author_role: "data_arch"
+confidence: "medium"
+---
+
+## Problem
+
+The transport DTO `RetryRequest` is leaking into the application core logic, specifically being passed into the `runAttempt` execution function.
+
+## Goal
+
+Model a domain representation for the command to be executed (e.g., a `CommandExecution` domain object) so the core application layer does not depend on the transport-specific `RetryRequest`.
+
+## Context
+
+While `executeRetry` correctly maps retry policies and schedules to domain models (`RetryPolicy`, `RetrySchedule`), the command execution details (`command`, `shell`, `timeoutSeconds`, `terminationGraceSeconds`) remain trapped in the transport DTO `RetryRequest`. `runAttempt` then directly consumes this DTO, meaning the application execution core is tightly coupled to the action input layer representation.
+
+## Evidence
+
+- path: "src/app/execute-retry.ts"
+  loc: "line 87"
+  note: "`runAttempt` takes `RetryRequest` directly instead of a domain-specific model for the command execution."
+- path: "src/action/read-inputs.ts"
+  loc: "lines 5-16"
+  note: "Defines `RetryRequest`, which mixes execution instructions with GitHub Action-specific configurations."
+
+## Change Scope
+
+- `src/app/execute-retry.ts`
+- `src/action/read-inputs.ts`


### PR DESCRIPTION
Emits 3 event files in `.jules/exchange/events/` capturing data architecture findings based on the observers contract constraints:

1. `duplicate_retry_on_type_data_arch.md`: Duplicate definition of the `RetryOn` string union in the DTO layer and Domain layer.
2. `duplicate_final_result_type_data_arch.md`: `RetryActionOutput` explicitly re-declaring the same shape and string literal outcome types as the `FinalResult` domain concept.
3. `transport_dto_leak_data_arch.md`: Core domain logic (`runAttempt`) directly consuming `RetryRequest` rather than a dedicated execution domain model.

Verified that tests continue to pass and new files fit the requested schema.

---
*PR created automatically by Jules for task [9718684648177931653](https://jules.google.com/task/9718684648177931653) started by @akitorahayashi*