### PR TITLE
docs(qa): emit high-signal qa observer findings

### DIFF
--- a/.jules/exchange/events/flaky_process_termination_tests_qa.md
+++ b/.jules/exchange/events/flaky_process_termination_tests_qa.md
@@ -1,0 +1,33 @@
+---
+label: "tests" # Must match a key in .jules/github-labels.json
+created_at: "2024-03-20"
+author_role: "qa" # e.g. taxonomy
+confidence: "high"
+---
+
+## Problem
+
+The test `tests/adapters/terminate-process-tree.test.ts` is flaky because it relies on timing and process lifecycle without direct control, resolving after arbitrary timeouts.
+
+## Goal
+
+Improve test determinism by eliminating timing assumptions in `terminateProcessTree.test.ts` and controlling process execution states explicitly where possible, or decoupling process status polling from `setTimeout` to use standard wait loops.
+
+## Context
+
+The `terminateProcessTree.test.ts` creates a real process and checks process termination via a custom `waitUntilStopped` loop hardcoded with `setTimeout(resolve, 100)`. This causes intermittent failures on busy or slow systems and increases the total test suite time. The reliance on `setTimeout` for testing state transitions rather than utilizing the `close` or `exit` events from the spawned child limits reliability and diagnosability. Determinism Over Retries: avoid timing-dependent flakiness.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "line 43"
+  note: "`waitUntilStopped` relies on a loop of `setTimeout(resolve, 100)` to verify the process died."
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "line 22"
+  note: "Arbitrary long timeout parameter of `10000` to prevent Vitest from aborting early due to slowness."
+
+## Change Scope
+
+- `tests/adapters/terminate-process-tree.test.ts`

--- a/.jules/exchange/events/hardcoded_timer_prevents_timeout_testing_qa.md
+++ b/.jules/exchange/events/hardcoded_timer_prevents_timeout_testing_qa.md
@@ -1,0 +1,34 @@
+---
+label: "tests" # Must match a key in .jules/github-labels.json
+created_at: "2024-03-20"
+author_role: "qa" # e.g. taxonomy
+confidence: "high"
+---
+
+## Problem
+
+The timeout feature in `executeRetry` uses a hardcoded `setTimeout` instead of abstracting time logic. There are no tests verifying that `executeRetry` correctly aborts attempts that exceed `timeoutSeconds`.
+
+## Goal
+
+Decouple time from the `executeRetry` orchestrator so the timeout behavior can be validated deterministically in unit tests without real delays.
+
+## Context
+
+The `executeRetry` function handles timeouts by calling `setTimeout` directly. The runtime dependencies interface already injects `sleep`, but timer creation and cancellation remain tightly coupled to the environment. Without injected timers, tests validating the timeout feature would either be slow and flaky, or missing entirely—which is the current state. Recovery cost from timeout-related bugs is currently high due to this missing test coverage.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "src/app/execute-retry.ts"
+  loc: "line 124"
+  note: "Direct usage of `setTimeout` for the timeout timer prevents controlling time in tests."
+- path: "tests/app/execute-retry.test.ts"
+  loc: "entire file"
+  note: "No tests validate the timeout behavior or signal handling."
+
+## Change Scope
+
+- `src/app/execute-retry.ts`
+- `tests/app/execute-retry.test.ts`

--- a/.jules/exchange/events/monolithic_action_metadata_test_qa.md
+++ b/.jules/exchange/events/monolithic_action_metadata_test_qa.md
@@ -1,0 +1,30 @@
+---
+label: "tests" # Must match a key in .jules/github-labels.json
+created_at: "2024-03-20"
+author_role: "qa" # e.g. taxonomy
+confidence: "high"
+---
+
+## Problem
+
+The test `tests/action/action-metadata.test.ts` has low diagnosability due to combining all metadata validation into one assertion block, leading to ambiguous failures.
+
+## Goal
+
+Refactor the metadata test into smaller, single-concern assertions to improve failure localization (diagnosability).
+
+## Context
+
+The `action-metadata.test.ts` reads the `action.yml` file and tests node execution, main file, required inputs, and outputs all within one `it` block. If the test fails, a developer must hunt down the exact line that failed without clear semantic groupings or focused boundary design. Recovery cost optimization demands breaking down these properties into discrete assertions.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "tests/action/action-metadata.test.ts"
+  loc: "line 19"
+  note: "Single test case validating inputs, outputs, and runner configuration simultaneously."
+
+## Change Scope
+
+- `tests/action/action-metadata.test.ts`


### PR DESCRIPTION
Creates event files in the `.jules/exchange/events/` directory documenting findings regarding test flakiness, diagnosability, and time control, as requested for the `qa` observer role.

---
*PR created automatically by Jules for task [5590677037889726917](https://jules.google.com/task/5590677037889726917) started by @akitorahayashi*