### PR TITLE
Add observer findings for missing test coverage

### DIFF
--- a/.jules/exchange/events/terminate_process_tree_uncovered_paths_cov.md
+++ b/.jules/exchange/events/terminate_process_tree_uncovered_paths_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2026-03-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Edge cases and fallback logic in `terminateProcessTree` (`src/adapters/terminate-process-tree.ts`) are untested, leaving process management fallbacks and SIGKILL escalations unverified.
+
+## Goal
+
+Add tests to ensure `terminateProcessTree` handles gracefully terminating processes via process groups (and the fallback) and correctly escalates to `SIGKILL` when `graceSeconds` timeout is exceeded.
+
+## Context
+
+The `terminateProcessTree` function is responsible for stopping the shell commands that are spawned. It contains critical process group termination fallbacks when `process.kill(-pid, signal)` fails, as well as an escalation to send `SIGKILL` if the process remains alive after `graceSeconds`. Currently, only the happy path of a process responding to termination is tested, but the failure of the process group kill, and the forced `SIGKILL` path are unverified, creating a major risk of orphaned processes if the fallback mechanisms silently fail.
+
+## Evidence
+
+- path: "src/adapters/terminate-process-tree.ts"
+  loc: "10-11,20-26"
+  note: "Fallback to direct pid signaling, and escalation to SIGKILL if `isAlive(pid)` is true are uncovered."
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "1-41"
+  note: "Tests focus purely on the happy path where a process is terminated without triggering the SIGKILL escalation."
+
+## Change Scope
+
+- `src/adapters/terminate-process-tree.ts`
+- `tests/adapters/terminate-process-tree.test.ts`

--- a/.jules/exchange/events/uncovered_signal_handlers_execute_retry_cov.md
+++ b/.jules/exchange/events/uncovered_signal_handlers_execute_retry_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2026-03-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Signal handlers (SIGINT, SIGTERM) and timeouts in `executeRetry` (`src/app/execute-retry.ts`) are completely uncovered by tests, representing a significant risk to process management and cancellation guarantees.
+
+## Goal
+
+Add tests to cover signal propagation and timeout behaviors to ensure processes are reliably terminated when requested or when they exceed their allowed time.
+
+## Context
+
+The `executeRetry` orchestrates commands and attempts to cleanly shut down the child process tree via signal handlers (SIGTERM, SIGINT) and timeouts. However, these critical paths are untested. If signal propagation fails or the timeout does not correctly terminate the child processes, it could lead to orphaned processes, resource leaks, or zombie build steps that hang CI runners indefinitely. The absence of assertions covering these paths masks a major liability.
+
+## Evidence
+
+- path: "src/app/execute-retry.ts"
+  loc: "110-161"
+  note: "Signal handlers (`onSigterm`, `onSigint`) and timeout termination logic are executed but there are no tests asserting they correctly clean up the process tree or result in the proper outcome."
+- path: "tests/app/execute-retry.test.ts"
+  loc: "1-105"
+  note: "Tests focus purely on iteration logic, policy evaluation, and scheduling delays, relying on mocked process completion. There are no tests to simulate signal events or a command exceeding `timeoutSeconds`."
+
+## Change Scope
+
+- `src/app/execute-retry.ts`
+- `tests/app/execute-retry.test.ts`

--- a/.jules/exchange/events/untested_run_shell_command_failures_cov.md
+++ b/.jules/exchange/events/untested_run_shell_command_failures_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2026-03-20"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Edge cases and failure modes in `runShellCommand` (`src/adapters/run-shell-command.ts`) are untested, including spawn failures, missing PIDs, and potential data-forwarding errors.
+
+## Goal
+
+Add tests to ensure `runShellCommand` correctly manages error handling paths, stream events (or ignoring those stream events), and process termination guarantees.
+
+## Context
+
+The `runShellCommand` adapter spawns the main child process, pipes output streams, and resolves the returned Promise with exit outcomes. The code explicitly attempts to handle missing `child.pid` or `error` events during execution, as well as ignoring exceptions writing to `stdout`/`stderr`. These critical sections of the adapter are entirely unexercised by current test paths.
+
+## Evidence
+
+- path: "src/adapters/run-shell-command.ts"
+  loc: "24-48"
+  note: "Error blocks for throwing on a missing PID, ignoring stdout/stderr exceptions, and catching `error` events are not tested."
+- path: "tests/adapters/run-shell-command.test.ts"
+  loc: "1-41"
+  note: "Existing tests do not assert failure paths when spawn completely fails, nor what occurs if writing output fails unexpectedly."
+
+## Change Scope
+
+- `src/adapters/run-shell-command.ts`
+- `tests/adapters/run-shell-command.test.ts`


### PR DESCRIPTION
As the `cov` observer, I have identified and emitted three event files for critical test coverage gaps in the `execute-retry.ts`, `run-shell-command.ts`, and `terminate-process-tree.ts` files. These gaps represent significant risks for process management, termination fallbacks, and command execution failures. The findings are documented in the `.jules/exchange/events/` directory and include specific file paths, line numbers, and impact assessments.

---
*PR created automatically by Jules for task [9389044082018912021](https://jules.google.com/task/9389044082018912021) started by @akitorahayashi*