### PR TITLE
refactor: Emit taxonomy observer findings

### DIFF
--- a/.jules/exchange/events/attempt_vs_retry_terminology_taxonomy.md
+++ b/.jules/exchange/events/attempt_vs_retry_terminology_taxonomy.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+A single concept—the current iteration number of the command execution—is inconsistently referred to as both `attempt` and `retryIndex`.
+
+## Goal
+
+Standardize on the term `attempt` for consistency across the core loop and utility functions, eliminating the redundant synonym.
+
+## Context
+
+In `src/app/execute-retry.ts`, the core loop iterant is clearly named `attempt` and passed cleanly to `runAttempt(..., attempt, ...)`. However, when fetching the delay for the next execution from `resolveRetryDelaySeconds`, this value is reassigned to `retryIndex`, creating an unnecessary synonym. This creates a conceptual collision where an attempt is treated structurally as an index, causing confusion because attempts are 1-based, whereas indices are typically 0-based. The schedule resolution logic in `src/domain/schedule.ts` adjusts for this by subtracting 1 from `retryIndex`, further indicating that `attempt` is the clearer, correct domain term.
+
+## Evidence
+
+- path: "src/app/execute-retry.ts"
+  loc: "49, 79-80"
+  note: "The variable `attempt` tracks iteration natively but is re-assigned to the alias `retryIndex` before passing to the schedule domain."
+- path: "src/domain/schedule.ts"
+  loc: "7-8, 10"
+  note: "The domain method is named `resolveRetryDelaySeconds` and accepts a parameter `retryIndex`, but internally subtracts 1 since it's actually an attempt count, not a true array index."
+- path: "src/domain/result.ts"
+  loc: "4"
+  note: "The concept is consistently named `attempt` inside `AttemptResult`, acting as the canonical term elsewhere."
+
+## Change Scope
+
+- `src/domain/schedule.ts`
+- `src/app/execute-retry.ts`

--- a/.jules/exchange/events/delay_terminology_taxonomy.md
+++ b/.jules/exchange/events/delay_terminology_taxonomy.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The concept of a fallback delay between attempts is referred to inconsistently across boundaries, mapped as `retryDelaySeconds` at the input boundary and as `defaultDelaySeconds` in the schedule domain.
+
+## Goal
+
+Ensure naming consistency between the configuration inputs and internal domain models. Either the input should be `defaultRetryDelaySeconds` or the schedule property should be `retryDelaySeconds`.
+
+## Context
+
+The `retry_delay_seconds` input represents the fallback or default delay when the `retry_delay_schedule_seconds` array runs out of predefined values (or is not provided). In `src/domain/schedule.ts`, this value is mapped to `defaultDelaySeconds`. This creates a conceptual disconnect where a single configuration value adopts two distinct names as it crosses from the `read-inputs` action boundary into the core `app/domain` boundaries. Following the principle of "Conventions Over Preference" and standard naming shape consistency, the internal name should reflect its origin or vice versa.
+
+## Evidence
+
+- path: "src/action/read-inputs.ts"
+  loc: "10, 24-25"
+  note: "Defines the property as `retryDelaySeconds` in the `RetryRequest` interface."
+- path: "src/app/execute-retry.ts"
+  loc: "44"
+  note: "Maps `request.retryDelaySeconds` to the internal schedule's `defaultDelaySeconds`."
+- path: "src/domain/schedule.ts"
+  loc: "2, 13"
+  note: "Names the property `defaultDelaySeconds` within the `RetrySchedule` interface."
+
+## Change Scope
+
+- `src/domain/schedule.ts`
+- `src/app/execute-retry.ts`

--- a/.jules/exchange/events/duplicate_result_type_taxonomy.md
+++ b/.jules/exchange/events/duplicate_result_type_taxonomy.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The exact same concept and data structure for the final execution outcome is represented by two distinct types: `FinalResult` in the domain and `RetryActionOutput` in the action boundary.
+
+## Goal
+
+Unify the data structure under a single canonical term (e.g., `FinalResult`) to enforce naming shape consistency across boundaries and avoid duplication.
+
+## Context
+
+The `FinalResult` interface defined in `src/domain/result.ts` represents the result of the entire execution process. When this result is passed to the action boundary to be emitted as GitHub Action outputs, the `emitOutputs` function in `src/action/emit-outputs.ts` redefines this exact shape as `RetryActionOutput`. The only difference is that `FinalResult` uses the `AttemptOutcome` type for `finalOutcome`, while `RetryActionOutput` hardcodes the string union `'success' | 'error' | 'timeout'`. This violates the principle of "One concept mapped to multiple terms" and introduces maintenance overhead if the outcome shape or possible values change.
+
+## Evidence
+
+- path: "src/domain/result.ts"
+  loc: "10-15"
+  note: "Defines the `FinalResult` interface representing the final execution state."
+- path: "src/action/emit-outputs.ts"
+  loc: "3-8"
+  note: "Defines the structurally identical `RetryActionOutput` interface, duplicating the concept under a new name."
+- path: "src/index.ts"
+  loc: "8"
+  note: "Passes the `result` (of type `FinalResult`) directly to `emitOutputs` (which expects `RetryActionOutput`), proving they represent the exact same concept."
+
+## Change Scope
+
+- `src/action/emit-outputs.ts`
+- `src/domain/result.ts`


### PR DESCRIPTION
Emit three event files highlighting naming inconsistencies and duplications as a taxonomy observer:
1. `duplicate_result_type_taxonomy.md`: Duplication between `FinalResult` and `RetryActionOutput`.
2. `delay_terminology_taxonomy.md`: Inconsistency between `retryDelaySeconds` and `defaultDelaySeconds`.
3. `attempt_vs_retry_terminology_taxonomy.md`: Ambiguity between `attempt` and `retryIndex`.

---
*PR created automatically by Jules for task [4629013148297266862](https://jules.google.com/task/4629013148297266862) started by @akitorahayashi*