### PR TITLE
Add Typescripter observer events

### DIFF
--- a/.jules/exchange/events/mixed_failure_semantics_typescripter.md
+++ b/.jules/exchange/events/mixed_failure_semantics_typescripter.md
@@ -1,0 +1,35 @@
+---
+label: "bugs"
+created_at: "2024-05-24"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`runShellCommand` and `runAttempt` mix exceptions (thrown synchronously or rejected asynchronously) with domain object returns (`AttemptResult`), causing system-level errors to bypass the retry loop and crash the action instead of resolving into an `error` outcome.
+
+## Goal
+
+Unify failure handling in `runAttempt` so that all command failures (both synchronous start failures and asynchronous rejections) resolve into a valid `AttemptResult` domain object.
+
+## Context
+
+The `executeRetry` function expects `runAttempt` to return an `AttemptResult`. However, if `dependencies.runCommand` throws (e.g., failed to start process) or if `running.completion` rejects, these errors bypass the retry logic, crashing the entire GitHub Action execution instead of triggering a retry for `error`.
+
+## Evidence
+
+- path: "src/adapters/run-shell-command.ts"
+  loc: "line 21-23"
+  note: "Throws a synchronous exception if process start fails."
+- path: "src/adapters/run-shell-command.ts"
+  loc: "line 42-45"
+  note: "Rejects the completion promise on child process error."
+- path: "src/app/execute-retry.ts"
+  loc: "line 164"
+  note: "Awaits the completion promise without a try/catch, causing rejections to bubble out of `runAttempt`."
+
+## Change Scope
+
+- `src/adapters/run-shell-command.ts`
+- `src/app/execute-retry.ts`

--- a/.jules/exchange/events/non_exhaustive_policy_handling_typescripter.md
+++ b/.jules/exchange/events/non_exhaustive_policy_handling_typescripter.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2024-05-24"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`shouldRetryFailure` uses sequential `if` statements over the `AttemptOutcome` discriminated union rather than an exhaustive `switch`, relying on a default fallback return (`return true`).
+
+## Goal
+
+Model state handling over `AttemptOutcome` using an exhaustive `switch` block so the compiler enforces handling for all possible missing or newly added outcome variants.
+
+## Context
+
+`AttemptOutcome` is a discriminated union of states. By checking individual cases and using a catch-all `return true;` fallback at the end, any new variants added to `AttemptOutcome` will silently fall through and become retryable by default, potentially violating policy.
+
+## Evidence
+
+- path: "src/domain/policy.ts"
+  loc: "line 10-33"
+  note: "Sequential if-statements evaluate policy logic without static exhaustiveness checking."
+
+## Change Scope
+
+- `src/domain/policy.ts`

--- a/.jules/exchange/events/primitive_timeout_state_typescripter.md
+++ b/.jules/exchange/events/primitive_timeout_state_typescripter.md
@@ -1,0 +1,34 @@
+---
+label: "bugs"
+created_at: "2024-05-24"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Timeout state inside `runAttempt` is modeled with a mutable boolean flag (`timedOut`) evaluated after the completion promise resolves, instead of racing promises to explicitly represent the state machine outcome.
+
+## Goal
+
+Model the timeout as a distinct resolution path (e.g., using `Promise.race`) so that the state machine logically represents either "completed" or "timed out", making invalid overlapping states unrepresentable.
+
+## Context
+
+Using a separate timer to set a boolean, then checking that boolean after awaiting the completion promise, creates an intermediate, loosely synchronized state where the process completes and the timer fires at the exact same moment. Modeling it as competing promises explicitly aligns with the async architecture and TypeScript's union type system.
+
+## Evidence
+
+- path: "src/app/execute-retry.ts"
+  loc: "line 107"
+  note: "Mutable `timedOut` boolean flag initialized."
+- path: "src/app/execute-retry.ts"
+  loc: "line 148"
+  note: "Timeout handler mutates the boolean flag asynchronously."
+- path: "src/app/execute-retry.ts"
+  loc: "line 170-174"
+  note: "Outcome resolution implicitly couples the mutated boolean with the process exit code using a nested ternary."
+
+## Change Scope
+
+- `src/app/execute-retry.ts`


### PR DESCRIPTION
This PR adds three Typescripter observer events in the `.jules/exchange/events/` directory detailing TypeScript architectural findings, focusing on failure semantics, state modeling, and boundary issues.

---
*PR created automatically by Jules for task [5305571062793080029](https://jules.google.com/task/5305571062793080029) started by @akitorahayashi*