### PR TITLE
Emit consistency observer events

### DIFF
--- a/.jules/exchange/events/mixed_quotes_in_yaml_examples_consistency.md
+++ b/.jules/exchange/events/mixed_quotes_in_yaml_examples_consistency.md
@@ -1,0 +1,28 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation in `docs/usage.md` shows an example with unquoted numeric list input for `retry_delay_schedule_seconds: 1,2,5,10` while other numeric inputs in the same example like `max_attempts`, `timeout_seconds`, and `termination_grace_seconds` are quoted.
+
+## Goal
+
+Ensure input formatting in examples is consistent. While YAML accepts both, mixing unquoted strings like `1,2,5,10` and quoted strings for numeric strings like `'5'` within the same code block is a documentation anti-pattern in terms of formatting and style rules, given GitHub Actions inputs are fundamentally strings.
+
+## Context
+
+GitHub Actions inputs are passed as strings. Using quotes for numeric values explicitly communicates this type behavior, which is standard practice in GitHub Actions documentation to avoid YAML type coercion surprises (e.g. `on`, `yes`, octal values). The example `Timeout-Only Retry Example` mixes these conventions.
+
+## Evidence
+
+- path: "docs/usage.md"
+  loc: "43"
+  note: "`retry_delay_schedule_seconds: 1,2,5,10` uses an unquoted string, while lines 40, 41, and 44 use quoted strings like `'5'`."
+
+## Change Scope
+
+- `docs/usage.md`

--- a/.jules/exchange/events/omitted_succeeded_output_consistency.md
+++ b/.jules/exchange/events/omitted_succeeded_output_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The execution sequence documented in `docs/architecture/boundary.md` is incomplete and contradicts the implemented behavior. It claims that `emit outputs with attempts, outcome, and exit code`, completely omitting `succeeded` which is emitted by the code.
+
+## Goal
+
+Update the documentation in `docs/architecture/boundary.md` to include `succeeded` output, so it conforms to the implementation in `src/action/emit-outputs.ts` and `src/domain/result.ts`.
+
+## Context
+
+The architecture boundary documentation lists the runtime execution flow. Step 5 says: `Emit final outputs with attempts, outcome, and exit code.` This leaves out the `succeeded` output.
+
+## Evidence
+
+- path: "docs/architecture/boundary.md"
+  loc: "44"
+  note: "Documentation mentions `Emit final outputs with attempts, outcome, and exit code.` missing the `succeeded` flag."
+- path: "src/action/emit-outputs.ts"
+  loc: "14-17"
+  note: "Implementation emits `attempts`, `final_exit_code`, `final_outcome`, and `succeeded`."
+
+## Change Scope
+
+- `docs/architecture/boundary.md`


### PR DESCRIPTION
This commit adds two events detailing documentation drift between `action.yml` inputs and outputs vs the `docs/` documentation directory, highlighting an omitted `succeeded` output and mixed quotes in YAML examples.

---
*PR created automatically by Jules for task [11201864591783077408](https://jules.google.com/task/11201864591783077408) started by @akitorahayashi*