### PR TITLE
jules: emit DevOps observer findings

### DIFF
--- a/.jules/exchange/events/monolithic_static_checks_devops.md
+++ b/.jules/exchange/events/monolithic_static_checks_devops.md
@@ -1,0 +1,32 @@
+---
+label: "refacts" # Must match a key in .jules/github-labels.json
+created_at: "2026-03-20"
+author_role: "devops" # e.g. taxonomy
+confidence: "high"
+---
+
+## Problem
+
+The static checks workflow executes all verification tasks (formatting, linting, typechecking, and dist verification) under a single monolithic `just check` command.
+
+## Goal
+
+Split monolithic static checks into separate, individually observable GitHub Actions jobs or steps to improve signal quality, failure isolation, and parallelization.
+
+## Context
+
+Running all static checks sequentially within a single script invocation (`just check`) hides the specific cause of a failure in the top-level CI dashboard. This "Monolithic verification path" anti-pattern conflates distinct verification domains (e.g., formatting vs. type safety vs. artifact integrity), inflating feedback latency because independent checks must wait for prior checks to finish.
+
+## Evidence
+
+- path: ".github/workflows/run-static-checks.yml"
+  loc: "25"
+  note: "Executes `just check` as a single monolithic step instead of distinct verification phases."
+- path: "justfile"
+  loc: "17-21"
+  note: "The `check` recipe groups `format:check`, `lint`, `typecheck`, and `verify:dist` sequentially."
+
+## Change Scope
+
+- `.github/workflows/run-static-checks.yml`
+- `justfile`

--- a/.jules/exchange/events/unpinned_third_party_actions_devops.md
+++ b/.jules/exchange/events/unpinned_third_party_actions_devops.md
@@ -1,0 +1,53 @@
+---
+label: "bugs" # Must match a key in .jules/github-labels.json
+created_at: "2026-03-20"
+author_role: "devops" # e.g. taxonomy
+confidence: "high"
+---
+
+## Problem
+
+Third-party GitHub Actions are unpinned and use mutable major version tags (e.g., `@v5`, `@v2`) instead of immutable commit SHAs.
+
+## Goal
+
+Pin all third-party GitHub Actions to specific, immutable commit SHAs to enforce trust boundaries and mitigate supply-chain risks.
+
+## Context
+
+Using mutable tags like `@v5` allows upstream action maintainers (or attackers who compromise the action repository) to modify the executed code without warning. Determinism and provenance are baseline requirements. Trust boundaries must be explicit at every handoff, including external artifacts.
+
+## Evidence
+
+- path: ".github/workflows/run-static-checks.yml"
+  loc: "19"
+  note: "Uses mutable tag `actions/checkout@v5` instead of a specific SHA."
+- path: ".github/workflows/run-tests.yml"
+  loc: "19"
+  note: "Uses mutable tag `actions/checkout@v5` instead of a specific SHA."
+- path: ".github/workflows/verify-e2e-linux.yml"
+  loc: "15"
+  note: "Uses mutable tag `actions/checkout@v5` instead of a specific SHA."
+- path: ".github/workflows/release.yml"
+  loc: "47"
+  note: "Uses mutable tag `actions/checkout@v5` instead of a specific SHA."
+- path: ".github/workflows/release.yml"
+  loc: "51"
+  note: "Uses mutable tag `softprops/action-gh-release@v2` instead of a specific SHA."
+- path: ".github/workflows/release.yml"
+  loc: "68"
+  note: "Uses mutable tag `actions/checkout@v5` instead of a specific SHA."
+- path: ".github/actions/setup/action.yml"
+  loc: "12"
+  note: "Uses mutable tag `actions/setup-node@v5` instead of a specific SHA."
+- path: ".github/actions/setup/action.yml"
+  loc: "17"
+  note: "Uses mutable tag `extractions/setup-just@v2` instead of a specific SHA."
+
+## Change Scope
+
+- `.github/workflows/run-static-checks.yml`
+- `.github/workflows/run-tests.yml`
+- `.github/workflows/verify-e2e-linux.yml`
+- `.github/workflows/release.yml`
+- `.github/actions/setup/action.yml`


### PR DESCRIPTION
This submission fulfills the requirements of the DevOps observer role.

Two event files are emitted to `.jules/exchange/events/`:
1. `unpinned_third_party_actions_devops.md`: Flags unpinned GitHub actions (e.g., `actions/checkout@v5`) which introduce supply-chain risks.
2. `monolithic_static_checks_devops.md`: Flags the monolithic `just check` script used in `run-static-checks.yml`, which conflates independent verification domains and hides signal quality.

Both files strictly adhere to the provided schema, assign correct labels (`bugs`, `refacts`), and include exact file-level evidence (paths and line numbers). No files outside the exchange directory were modified.

---
*PR created automatically by Jules for task [13916615148220635750](https://jules.google.com/task/13916615148220635750) started by @akitorahayashi*