### PR TITLE
Emit coverage events for `execute-retry` error handling paths

### DIFF
--- a/.jules/exchange/events/uncovered_sanitize_command_edge_cases_cov.md
+++ b/.jules/exchange/events/uncovered_sanitize_command_edge_cases_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-03-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+`sanitizeCommand` has low branch and statement coverage, specifically regarding its handling of edge cases for empty or whitespace-only commands.
+
+## Goal
+
+Implement tests for `sanitizeCommand` to verify that it gracefully handles empty strings, commands containing only spaces, and multi-argument commands, achieving complete branch coverage.
+
+## Context
+
+The `sanitizeCommand` function parses shell commands to extract the base executable name for logging. The coverage report indicates line coverage at 69.23% and branch coverage at just 25% (lines 4-5 and 12-13 are uncovered). Specifically, the branch `if (parts.length === 0 || !parts[0])` returning `"<empty>"` and the branch `if (argsCount === 0)` are currently untested. These gaps reduce confidence in the logging utility's safety against unexpected inputs.
+
+## Evidence
+
+- path: "src/app/execute-retry/sanitize-command.ts"
+  loc: "Lines 4-5, 12-13"
+  note: "Branches handling zero-length or no-argument commands are not tested. Branch coverage is 25%."
+
+## Change Scope
+
+- `src/app/execute-retry/sanitize-command.ts`
+- `tests/app/sanitize-command.test.ts`

--- a/.jules/exchange/events/uncovered_signal_termination_errors_cov.md
+++ b/.jules/exchange/events/uncovered_signal_termination_errors_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-03-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Signal termination handlers (`SIGTERM` and `SIGINT`) have uncovered catch blocks in `terminate-command-on-signal.ts`. The error handling when terminating a process tree or when a handler throws an error is not tested, masking potential failure modes.
+
+## Goal
+
+Add tests to ensure that when signal termination fails, the error is correctly caught and logged, and the process still exits gracefully to avoid hanging indefinitely.
+
+## Context
+
+The `registerCommandTerminationOnSignal` function listens for `SIGTERM` and `SIGINT` to clean up child processes. If the `terminateProcessTree` dependency throws an error, the code has a catch block that logs the failure. Additionally, if the `onSignal` promise throws, another catch block logs the error before forcing process exit. These error paths are missing from the current test suite (lines 31, 40-42, 52-54), leaving these critical cleanup routines vulnerable to regressions that could lead to dangling processes or unhandled promise rejections.
+
+## Evidence
+
+- path: "src/app/execute-retry/terminate-command-on-signal.ts"
+  loc: "Lines 31, 40-42, 52-54"
+  note: "Catch blocks handling termination errors and signal handler rejections are untested. Vitest coverage reports 77.77% branch coverage."
+
+## Change Scope
+
+- `src/app/execute-retry/terminate-command-on-signal.ts`
+- `tests/app/terminate-command-on-signal.test.ts`

--- a/.jules/exchange/events/uncovered_timeout_termination_errors_cov.md
+++ b/.jules/exchange/events/uncovered_timeout_termination_errors_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-03-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Timeout-induced termination failure paths and edge case completions in `await-attempt-outcome.ts` lack test coverage. The branch logic handling `terminateProcessTree` errors and delayed final completions are currently untested.
+
+## Goal
+
+Provide test coverage for scenarios where an attempt times out, and the subsequent attempt to forcefully terminate the process tree fails or takes too long, confirming the fallback 'timeout' safe outcome is returned.
+
+## Context
+
+In `await-attempt-outcome.ts`, if a command times out, it invokes `terminateProcessTree`. If this termination fails, an error is caught and logged. Furthermore, a secondary fallback timeout (5000ms) awaits the command's final completion, returning a 'timeout' outcome regardless of success. Lines 48-52 (termination failure), 64-68 (secondary timeout completion timeout), and 82-89 (finally blocks) have 0% coverage. These represent the critical error paths of state transitions during timeouts; without tests, regressions here might lead to stalled action executions or unhandled exceptions.
+
+## Evidence
+
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "Lines 48-52, 64-68, 82-89"
+  note: "Catch block for timeout termination failures and the secondary termination timeout branches are uncovered."
+
+## Change Scope
+
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `tests/app/await-attempt-outcome.test.ts`


### PR DESCRIPTION
This submission emits three event files detailing critical test coverage gaps found in `execute-retry`:
- `uncovered_signal_termination_errors_cov.md` for untested signal handler catch blocks in `terminate-command-on-signal.ts`.
- `uncovered_timeout_termination_errors_cov.md` for uncovered fallback terminations and secondary timeouts in `await-attempt-outcome.ts`.
- `uncovered_sanitize_command_edge_cases_cov.md` for untested branches handling empty or zero-argument commands in `sanitize-command.ts`.

---
*PR created automatically by Jules for task [250075727388803449](https://jules.google.com/task/250075727388803449) started by @akitorahayashi*