### PR TITLE
docs: emit observer QA events for testing quality issues

### DIFF
--- a/.jules/exchange/events/fake_timers_with_real_os_processes_qa.md
+++ b/.jules/exchange/events/fake_timers_with_real_os_processes_qa.md
@@ -1,0 +1,36 @@
+---
+label: "tests"
+created_at: "2024-03-24"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+`tests/adapters/terminate-process-tree.test.ts` uses fake timers (`vi.useFakeTimers()`) to advance time (`vi.advanceTimersByTimeAsync()`) while asserting real OS-level child process termination.
+
+## Goal
+
+Remove fake timers from tests involving real OS processes and use real timing or explicit process events (like `on('close')`) to ensure deterministic behavior.
+
+## Context
+
+Using fake timers to simulate timeouts while interacting with real external resources (like child processes) is non-deterministic. The process takes real time to respond to signals (`SIGTERM`, `SIGKILL`), but the fake timers advance immediately, potentially checking assertions before the OS has actually transitioned the process state. This leads to flaky tests and race conditions. Tests should either use real timeouts and await process exit events, or the process boundaries should be mocked entirely.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "line 8"
+  note: "Before each hook uses `vi.useFakeTimers()`"
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "line 36"
+  note: "Advances fake timers by 1000ms while waiting for a real process to terminate"
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "line 72"
+  note: "Advances fake timers by 2000ms after sending signal to a real process"
+
+## Change Scope
+
+- `tests/adapters/terminate-process-tree.test.ts`

--- a/.jules/exchange/events/global_process_mocking_and_diagnosability_qa.md
+++ b/.jules/exchange/events/global_process_mocking_and_diagnosability_qa.md
@@ -1,0 +1,36 @@
+---
+label: "tests"
+created_at: "2024-03-24"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+`tests/app/execute-retry.test.ts` mutates global `process` methods (`process.exit`, `process.once`, `process.off`) in a specific test without restoring them afterward in an `afterEach` hook or within the test itself, causing diagnosability issues via shared global state leakage.
+
+## Goal
+
+Ensure all global environment mocks (like `process` methods) are properly isolated per test by restoring all mocks in `afterEach` or avoiding global mutation if possible.
+
+## Context
+
+Mutating globals inside a specific `it` block and failing to restore them can lead to other seemingly unrelated tests failing because they inadvertently run against a mocked version of `process.exit` or event handlers. This shared mutable state destroys failure diagnosability because if a test fails due to leaked state, the cause is an entirely different file or test, frustrating developers and obscuring the real failure point. The test suite is currently missing an `afterEach` block containing `vi.restoreAllMocks()` or specific un-mocking steps for process globals.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "tests/app/execute-retry.test.ts"
+  loc: "line 84-89"
+  note: "Mocks `process.once`, `process.off`, and `process.exit` without cleaning them up."
+- path: "tests/app/execute-retry.test.ts"
+  loc: "line 78"
+  note: "Test block 'interrupts running command and terminates process tree on $signal' contains global mutations."
+- path: "tests/app/execute-retry.test.ts"
+  loc: "line 36"
+  note: "The `describe('executeRetry')` block lacks an `afterEach(() => vi.restoreAllMocks())` hook."
+
+## Change Scope
+
+- `tests/app/execute-retry.test.ts`

--- a/.jules/exchange/events/mocked_core_modules_boundary_qa.md
+++ b/.jules/exchange/events/mocked_core_modules_boundary_qa.md
@@ -1,0 +1,36 @@
+---
+label: "tests"
+created_at: "2024-03-24"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+`tests/adapters/run-shell-command.test.ts` has a fuzzy and problematic boundary design between asserting real child process logic and simulating mock failures, relying on globally mocking a core node module (`node:child_process`).
+
+## Goal
+
+Decouple tests from core Node module internals by making the dependency injection explicit for testing boundaries, or ensure the global `child_process` mock isn't stateful and conflicting when tests alternate between real execution and simulated errors.
+
+## Context
+
+The test file `tests/adapters/run-shell-command.test.ts` uses `vi.mock('node:child_process', ...)` to globally wrap `spawn`. Some tests use the original `spawn` implementation to run actual shell scripts (like `tests/fixtures/commands/emit-stdout-and-stderr.sh`), effectively using real `child_process` capabilities. Other tests override `vi.mocked(spawn)` to simulate errors (`it('throws an error if the process fails to start and has no pid')`). Because `spawn` is a core Node module, mocking it globally while also using it to spawn real processes in the same file creates a brittle, confusing test boundary. The tests assert behaviors against the internal `spawn` contract rather than purely testing externally visible behavior or explicitly injecting an interface that could be stubbed cleanly. This increases maintenance cost and can lead to unexpected failures if `vitest` or other parallel tests happen to use `child_process`.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "tests/adapters/run-shell-command.test.ts"
+  loc: "line 7-13"
+  note: "Globally mocks the core module `node:child_process` and replaces `spawn`."
+- path: "tests/adapters/run-shell-command.test.ts"
+  loc: "line 26"
+  note: "Test block 'returns zero exit code when command succeeds' runs real fixture, relying on `actual.spawn` inside the mock factory."
+- path: "tests/adapters/run-shell-command.test.ts"
+  loc: "line 47"
+  note: "Test block 'throws an error if the process fails to start and has no pid' overrides the mock to simulate failure."
+
+## Change Scope
+
+- `tests/adapters/run-shell-command.test.ts`


### PR DESCRIPTION
Based on the `QA` observer role instructions, evaluated the test suite for flakiness, structural boundary design, and diagnosability. Emitted three findings.

---
*PR created automatically by Jules for task [1830571140073568801](https://jules.google.com/task/1830571140073568801) started by @akitorahayashi*