### PR TITLE
refactor(events): emit typescripter observer events

### DIFF
--- a/.jules/exchange/events/ambiguous_failure_semantics_in_core_typescripter.md
+++ b/.jules/exchange/events/ambiguous_failure_semantics_in_core_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-24"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+The core application layer mixes failure semantics. `executeAttempt` wraps domain execution in a try-catch block that swallows unknown errors and coercing them to a safe generic outcome (`outcome: 'error', exitCode: null`). It also handles both standard returns and exceptions inconsistently.
+
+## Goal
+
+Ensure a consistent failure contract. `executeAttempt` should use typed Result objects (or specific error classes) to handle process initiation/execution errors distinctly from command exit statuses. Swallowing unknown exceptions into a generic failure outcome masks the true cause of failure and prevents proper escalation.
+
+## Context
+
+Catch blocks that swallow `unknown` errors and coerce them to `any` or generic default domains make debugging impossible and mask systemic failures (e.g. process spawn failure vs command error). The failure mode needs to be explicit, and true runtime exceptions shouldn't be flattened into standard failure paths.
+
+## Evidence
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "47-56"
+  note: "try-catch block intercepts `error: unknown`, converts the message to string, logs it, and silently returns an `AttemptResult` with `outcome: 'error'`, masking whether the process failed to start or if something else failed."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "63-68"
+  note: "Similar pattern swallowing `error: unknown` on termination attempts without escalating."
+
+## Change Scope
+
+- `src/app/execute-retry/execute-attempt.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`

--- a/.jules/exchange/events/flat_state_encoding_in_results_typescripter.md
+++ b/.jules/exchange/events/flat_state_encoding_in_results_typescripter.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-03-24"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`AttemptResult` and `FinalResult` use flat interfaces that encode state with a string (`outcome`) alongside nullable properties (`exitCode: number | null`) and redundant flags (`succeeded: boolean`). This allows invalid state combinations to be represented, such as a `'success'` outcome with an `exitCode` of `null` and `succeeded: false`.
+
+## Goal
+
+Refactor `AttemptResult` and `FinalResult` into discriminated unions keyed by `outcome` (or `finalOutcome`), making invalid states unrepresentable. The redundant `succeeded` flag should be removed from the domain model and derived only when needed at the transport/action layer.
+
+## Context
+
+TypeScript's discriminated unions provide compiler-enforced state exhaustiveness and prevent unrepresentable states. Using flat interfaces with nullable fields and boolean flags forces consumers to guess if combinations like `outcome: 'success'` and `exitCode: null` are possible, violating the principle of making invalid states unrepresentable.
+
+## Evidence
+
+- path: "src/domain/result.ts"
+  loc: "3-8"
+  note: "`AttemptResult` encodes outcome as a string and allows `exitCode: number | null` across all outcomes, which means success can erroneously have a null exit code."
+- path: "src/domain/result.ts"
+  loc: "9-14"
+  note: "`FinalResult` includes a redundant `succeeded` boolean alongside `finalOutcome`, allowing conflicting combinations."
+
+## Change Scope
+
+- `src/domain/result.ts`
+- `src/app/execute-retry/index.ts`
+- `src/action/emit-outputs.ts`

--- a/.jules/exchange/events/unvalidated_type_assertions_boundary_typescripter.md
+++ b/.jules/exchange/events/unvalidated_type_assertions_boundary_typescripter.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-03-24"
+author_role: "typescripter"
+confidence: "medium"
+---
+
+## Problem
+
+Type assertions are used in `awaitAttemptOutcome.ts` (`as const`) to create local discriminants instead of defining a concrete domain boundary or generic result type for process outcomes. The promise race logic constructs inline objects with `type: 'completion' as const` or `type: 'timeout' as const`, creating implicit contracts that aren't statically validated.
+
+## Goal
+
+Define explicit sum types for Promise race outcomes instead of anonymous inline objects and type casting, keeping runtime boundary contracts clear and maintainable.
+
+## Context
+
+While `as const` creates a valid type signature, constructing anonymous types locally overcomplicates the module and reduces clarity. Defining a proper sum type (e.g. `type RaceOutcome = { type: 'completion', exitCode: number } | { type: 'timeout' }`) clarifies the possible internal states of `awaitAttemptOutcome` before resolving to `AttemptExecutionOutcome`.
+
+## Evidence
+
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "27"
+  note: "Uses `type: 'completion' as const` to simulate a discriminant."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "44"
+  note: "Uses `type: 'timeout' as const` for the timeout branch."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "74-78"
+  note: "Repeats the same inline object construction during final termination wait."
+
+## Change Scope
+
+- `src/app/execute-retry/await-attempt-outcome.ts`


### PR DESCRIPTION
Emitted three high-signal observer events from the `typescripter` perspective documenting specific type-system issues: flat state encoding instead of discriminated unions, mixed generic failure semantics that mask system vs domain errors, and implicit sum types via `as const`. Used explicit domain code surface as evidence for all findings.

---
*PR created automatically by Jules for task [18087517188629720958](https://jules.google.com/task/18087517188629720958) started by @akitorahayashi*