### PR TITLE
Emit taxonomy events for codebase vocabulary and naming consistency

### DIFF
--- a/.jules/exchange/events/command_execution_blueprint_vs_instance_taxonomy.md
+++ b/.jules/exchange/events/command_execution_blueprint_vs_instance_taxonomy.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "medium"
+---
+
+## Problem
+
+The name `CommandExecution` is used in the domain layer to describe the *configuration* or *blueprint* of a command to be executed (its string, shell, timeouts), not the actual execution instance itself. In contrast, `RunningCommand` (in adapters) represents an active execution.
+
+## Goal
+
+Rename `CommandExecution` to clearly reflect that it is a configuration or specification object, distinct from the active execution instance.
+
+## Context
+
+`src/domain/command.ts` defines `CommandExecution` which contains the string command, shell, and timeouts. This is passed to `executeAttempt` and `awaitAttemptOutcome`. However, the name implies an active process or a completed execution. The actual active process is represented by `RunningCommand` from the adapter layer. Using the word "Execution" for the static configuration creates ambiguity about the object's lifecycle phase. A name like `CommandBlueprint`, `CommandSpec`, or `CommandConfig` would more accurately reflect its role.
+
+## Evidence
+
+- path: "src/domain/command.ts"
+  loc: "lines 1-6"
+  note: "Defines `CommandExecution` as purely static configuration properties (`command`, `shell`, `timeoutSeconds`, `terminationGraceSeconds`)."
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "lines 15-19"
+  note: "`executeAttempt` takes a `CommandExecution` and creates a `RunningCommand`."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "line 21"
+  note: "`awaitAttemptOutcome` accepts both a `CommandExecution` (for config like timeouts) and a `RunningCommand` (for the actual promise)."
+
+## Change Scope
+
+- `src/domain/command.ts`
+- `src/app/execute-retry/execute-attempt.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `src/app/execute-retry/index.ts`

--- a/.jules/exchange/events/delay_adapter_vs_domain_delay_taxonomy.md
+++ b/.jules/exchange/events/delay_adapter_vs_domain_delay_taxonomy.md
@@ -1,0 +1,44 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The concept of a pause or waiting period is fragmented between two distinct adapters, `delay` (which returns a cancellable promise) and `sleep` (which returns a simple promise). This creates an unclear boundary and requires the domain/application layer to know which specific implementation detail to call depending on if cancellation is needed.
+
+## Goal
+
+Consolidate the vocabulary around pausing execution into a single, unified concept (e.g., `sleep` or `delay`) that optionally supports cancellation, removing the artificial distinction created by adapter implementation details.
+
+## Context
+
+In `src/adapters/delay.ts` and `src/adapters/sleep.ts`, two separate files provide essentially the same domain concept: waiting for a specific duration. `execute-retry-dependencies.ts` maps both of these as distinct concepts into the application layer. This requires the consumer (`index.ts` and `await-attempt-outcome.ts`) to choose between them based solely on whether they need cancellation capabilities, violating the principle of abstracting implementation details.
+
+## Evidence
+
+- path: "src/adapters/delay.ts"
+  loc: "line 1"
+  note: "Defines `delay` as a function returning an object with `promise` and `cancel`."
+- path: "src/adapters/sleep.ts"
+  loc: "line 1"
+  note: "Defines `sleep` as a function returning a simple `Promise<void>`."
+- path: "src/app/execute-retry/execute-retry-dependencies.ts"
+  loc: "lines 11-15"
+  note: "Requires both `delay` and `sleep` as distinct dependencies for the application layer."
+- path: "src/app/execute-retry/index.ts"
+  loc: "line 82"
+  note: "Uses `dependencies.sleep` for the retry pause."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "lines 39, 70"
+  note: "Uses `dependencies.delay` for command and termination timeouts."
+
+## Change Scope
+
+- `src/adapters/delay.ts`
+- `src/adapters/sleep.ts`
+- `src/app/execute-retry/execute-retry-dependencies.ts`
+- `src/app/execute-retry/index.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`

--- a/.jules/exchange/events/outcome_property_shadowing_taxonomy.md
+++ b/.jules/exchange/events/outcome_property_shadowing_taxonomy.md
@@ -1,0 +1,41 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The terms `outcome` and `exitCode` are defined distinctly at the attempt level (`AttemptResult`), but are mapped to `finalOutcome` and `finalExitCode` in the `FinalResult` aggregate, and further as `final_outcome` and `final_exit_code` in the GitHub Action outputs. However, the action outputs are defined simply as `attempts` and `succeeded`, creating inconsistent prefixing.
+
+## Goal
+
+Align the naming of result properties between the single-attempt view, the final aggregate view, and the user-facing action outputs.
+
+## Context
+
+The `AttemptResult` domain model uses `outcome` and `exitCode`. The `FinalResult` uses `finalOutcome` and `finalExitCode`. However, the final result also includes `attempts` and `succeeded` which don't have the `final` prefix, despite representing the final state. This prefixing leaks into the user-facing outputs (`final_exit_code`, `final_outcome` vs `attempts`, `succeeded`), making the API inconsistent. If it's a "final" state, either all properties should indicate it, or none should, relying on the context (the output of the action) to imply finality.
+
+## Evidence
+
+- path: "src/domain/result.ts"
+  loc: "lines 4-6"
+  note: "`AttemptResult` properties: `attempt`, `outcome`, `exitCode`"
+- path: "src/domain/result.ts"
+  loc: "lines 9-13"
+  note: "`FinalResult` properties: `attempts`, `finalExitCode`, `finalOutcome`, `succeeded`"
+- path: "action.yml"
+  loc: "lines 40-47"
+  note: "Action outputs: `attempts`, `final_exit_code`, `final_outcome`, `succeeded`"
+- path: "src/index.ts"
+  loc: "line 14"
+  note: "Log string uses mixed prefixing: `final_outcome`, `final_exit_code`"
+
+## Change Scope
+
+- `src/domain/result.ts`
+- `src/action/emit-outputs.ts`
+- `action.yml`
+- `src/index.ts`
+- `README.md`


### PR DESCRIPTION
This submission emits three event files according to the `taxonomy` observer role.

The findings highlight inconsistencies and shared vocabulary issues in the repository:
1. `delay_adapter_vs_domain_delay_taxonomy.md`: Evaluates the artificial distinction between `sleep` (no cancellation) and `delay` (cancellable) adapters.
2. `outcome_property_shadowing_taxonomy.md`: Documents the inconsistent usage of `outcome`/`exitCode` versus `final_outcome`/`final_exit_code` across the domain boundary and GitHub Action outputs.
3. `command_execution_blueprint_vs_instance_taxonomy.md`: Identifies that `CommandExecution` represents static configuration, while `RunningCommand` is the actual instance, creating lifecycle ambiguity.

The files adhere to the event schema, include strict file-level evidence, and modify zero files outside `.jules/exchange/`. Tests and linting were run successfully to verify the environment stability.

---
*PR created automatically by Jules for task [10086443416517145983](https://jules.google.com/task/10086443416517145983) started by @akitorahayashi*