### PR TITLE
Docs: Emit consistency event for missing input defaults in README

### DIFF
--- a/.jules/exchange/events/missing_defaults_in_readme_consistency.md
+++ b/.jules/exchange/events/missing_defaults_in_readme_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The Action Contract section in `README.md` documents inputs with their optionality and some defaults, but omits the default values for `shell`, `retry_delay_seconds`, and `termination_grace_seconds` which are defined in `action.yml` and `docs/configuration/inputs.md`.
+
+## Goal
+
+Update `README.md` to include the defaults for `shell` (bash), `retry_delay_seconds` (0), and `termination_grace_seconds` (5) to match the implementation in `action.yml`.
+
+## Context
+
+Users reading the `README.md` might assume there are no defaults for these optional inputs, leading to misunderstanding the action's fallback behavior. The documentation is inconsistent because `retry_on` and `continue_on_error` explicitly mention their defaults.
+
+## Evidence
+
+- path: "README.md"
+  loc: "27-36"
+  note: "Inputs `shell`, `retry_delay_seconds`, and `termination_grace_seconds` are listed as `(optional)` but their default values are missing."
+- path: "action.yml"
+  loc: "12, 20, 36"
+  note: "`shell` has default `bash`, `retry_delay_seconds` has default `'0'`, and `termination_grace_seconds` has default `'5'`."
+
+## Change Scope
+
+- `README.md`


### PR DESCRIPTION
I have completed the task of exploring the codebase and emitting a consistency event.

**Actions taken:**
1. Explored the codebase to understand the inputs and the existing consistency issues.
2. Verified that `README.md` documents `shell`, `retry_delay_seconds`, and `termination_grace_seconds` as `(optional)` but omits their default values (`bash`, `0`, and `5` respectively), which are properly defined in `action.yml` and `docs/configuration/inputs.md`.
3. Checked out the branch `jules-observer-consistency`.
4. Emitted the findings as `.jules/exchange/events/missing_defaults_in_readme_consistency.md` using the exact schema required for events.
5. Successfully ran all tests, formatting, and linting checks.
6. Restored `.jules/github-labels.json` to ensure no changes were made outside the `.jules/exchange/` directory as requested.

---
*PR created automatically by Jules for task [12033660677175739854](https://jules.google.com/task/12033660677175739854) started by @akitorahayashi*