### PR TITLE
docs: establish canonical scribe documentation topology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@ Tests are under `tests/`.
 Documentation is under `docs/`.
 Automation is under `.github/workflows/`.
 
+## Documentation Routing
+
+- [Usage](docs/usage.md): workflow examples and outputs
+- [Architecture Boundary](docs/architecture/boundary.md): runtime boundaries and flow
+- [Action Inputs](docs/configuration/inputs.md): input and output reference
+
 ## Repository Layout
 
 `action.yml` defines action inputs and outputs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,3 @@ Release automation on `main` runs `npm run package`, commits `dist/` when change
 
 The repository versions one action. Consumer-facing tags follow `vX.Y.Z`, and the moving major tag for workflows is `v1`.
 Release automation is manually dispatched with an `X.Y.Z` input, validates it on `main`, creates `vX.Y.Z`, moves `v1`, and publishes the GitHub Release.
-
-## Documentation
-
-`README.md` is the public front door. `docs/` owns task-oriented usage, durable architecture, and configuration reference surfaces.

--- a/README.md
+++ b/README.md
@@ -21,37 +21,6 @@ The action owns:
     retry_delay_seconds: '5'
 ```
 
-## Action Contract
-
-Inputs:
-
-- `command` (required)
-- `max_attempts` (required)
-- `shell` (optional, default: `bash`)
-- `timeout_seconds` (optional)
-- `retry_delay_seconds` (optional, default: `'0'`)
-- `retry_delay_schedule_seconds` (optional)
-- `retry_on` (optional, `any | error | timeout`, default: `any`)
-- `retry_on_exit_codes` (optional)
-- `continue_on_error` (optional, default: `false`)
-- `termination_grace_seconds` (optional, default: `'5'`)
-
-Outputs:
-
-- `attempts`
-- `final_exit_code`
-- `final_outcome`
-- `succeeded`
-- `final_stdout`
-
-## Runtime Flow
-
-1. Read and validate retry action inputs.
-2. Execute one command attempt.
-3. Apply timeout, termination, and retry policy.
-4. Wait between attempts when retries are allowed.
-5. Emit final outputs describing outcome, attempts, and final stdout.
-
 ## Documentation
 
 - [Usage](docs/usage.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,7 @@ This directory is the central documentation index for `retry`.
 
 ## Usage
 
-- [Usage](usage.md): workflow examples, retry outputs, and local verification entrypoints
-
-The action usage describes retry policy inputs and final execution outputs.
+- [Usage](usage.md): standard and timeout-only workflow examples
 
 ## Architecture
 

--- a/docs/architecture/boundary.md
+++ b/docs/architecture/boundary.md
@@ -1,18 +1,5 @@
 # Architecture
 
-## Repository Boundary
-
-`retry` is a single-action repository.
-
-The repository surfaces are:
-
-- `action.yml`: public action contract
-- `src/`: runtime implementation
-- `tests/`: repository-owned tests aligned to runtime boundaries
-- `dist/`: committed package output refreshed only by release automation
-- `docs/`: usage, configuration, and architecture documentation
-- `.github/workflows/`: CI and verification workflows
-
 ## Runtime Boundary Model
 
 The runtime boundaries are:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,25 +15,6 @@ The repository-owned end-to-end verification path targets Linux runners.
 
 This configuration retries non-zero command failures up to three attempts.
 
-## Input Behavior
-
-Required inputs:
-
-- `command`
-- `max_attempts`
-
-Optional policy inputs include timeout, fixed delay, delay schedule, failure class policy, exit-code filters, continue-on-error mode, and termination grace timing.
-
-The output surface is:
-
-- `attempts`
-- `final_exit_code`
-- `final_outcome`
-- `succeeded`
-- `final_stdout`
-
-`final_stdout` contains the final attempt stdout exactly as emitted by the command.
-
 ## Structured Output Example
 
 ```yaml
@@ -66,14 +47,3 @@ The output surface is:
 ```
 
 This configuration retries only timeout failures and applies attempt-specific delays.
-
-## Local Verification
-
-Repository-local verification commands are:
-
-- `just fix`
-- `just check`
-- `just test`
-
-`just fix` applies formatter and safe lint fixes.
-`just check` validates format, lint, and type safety.


### PR DESCRIPTION
Refactored repository documentation to match the canonical Scribe contract topology. Cleaned up redundant information across multiple markdown surfaces and established clear routing in `README.md`, `AGENTS.md`, and `docs/README.md`. Tests, formatting, and linting all pass.

---
*PR created automatically by Jules for task [11495137236039212232](https://jules.google.com/task/11495137236039212232) started by @akitorahayashi*