### PR TITLE
refactor: use explicit sum types for promise race outcomes and escalate execution failures

### DIFF
--- a/src/app/execute-retry/await-attempt-outcome.ts
+++ b/src/app/execute-retry/await-attempt-outcome.ts
@@ -28,13 +28,12 @@ export async function awaitAttemptOutcome(
   runningCommand: RunningCommand,
   dependencies: AwaitAttemptOutcomeDependencies,
 ): Promise<AttemptExecutionOutcome> {
-  const completionPromise: Promise<RaceOutcome> = runningCommand.completion.then(
-    (completion) => ({
+  const completionPromise: Promise<RaceOutcome> =
+    runningCommand.completion.then((completion) => ({
       type: 'completion',
       exitCode: completion.exitCode,
       stdout: completion.stdout,
-    }),
-  )
+    }))
 
   if (command.timeoutSeconds === undefined) {
     const completion = await completionPromise
@@ -83,7 +82,9 @@ export async function awaitAttemptOutcome(
             ...res,
           }),
         ),
-        terminationTimeout.promise.then((): RaceOutcome => ({ type: 'timeout' })),
+        terminationTimeout.promise.then(
+          (): RaceOutcome => ({ type: 'timeout' }),
+        ),
       ])
 
       if (finalCompletion.type === 'timeout') {

--- a/src/app/execute-retry/await-attempt-outcome.ts
+++ b/src/app/execute-retry/await-attempt-outcome.ts
@@ -18,20 +18,29 @@ interface AttemptExecutionOutcome {
   stdout: string
 }
 
+type RaceOutcome =
+  | { type: 'completion'; exitCode: number | null; stdout: string }
+  | { type: 'timeout' }
+
 export async function awaitAttemptOutcome(
   command: CommandExecution,
   attempt: number,
   runningCommand: RunningCommand,
   dependencies: AwaitAttemptOutcomeDependencies,
 ): Promise<AttemptExecutionOutcome> {
-  const completionPromise = runningCommand.completion.then((completion) => ({
-    type: 'completion' as const,
-    exitCode: completion.exitCode,
-    stdout: completion.stdout,
-  }))
+  const completionPromise: Promise<RaceOutcome> = runningCommand.completion.then(
+    (completion) => ({
+      type: 'completion',
+      exitCode: completion.exitCode,
+      stdout: completion.stdout,
+    }),
+  )
 
   if (command.timeoutSeconds === undefined) {
     const completion = await completionPromise
+    if (completion.type === 'timeout') {
+      throw new Error('Unexpected timeout when timeout is undefined')
+    }
     return {
       outcome: completion.exitCode === 0 ? 'success' : 'error',
       exitCode: completion.exitCode,
@@ -42,9 +51,9 @@ export async function awaitAttemptOutcome(
   const timeout = dependencies.delay(command.timeoutSeconds * 1000)
 
   try {
-    const result = await Promise.race([
+    const result: RaceOutcome = await Promise.race([
       completionPromise,
-      timeout.promise.then(() => ({ type: 'timeout' as const })),
+      timeout.promise.then((): RaceOutcome => ({ type: 'timeout' })),
     ])
 
     if (result.type === 'completion') {
@@ -59,27 +68,22 @@ export async function awaitAttemptOutcome(
       `Attempt ${attempt} timed out after ${command.timeoutSeconds}s.`,
     )
 
-    try {
-      await dependencies.terminateProcessTree(
-        runningCommand.pid,
-        command.terminationGraceSeconds,
-      )
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error)
-      core.error(
-        `Failed timeout termination pid=${runningCommand.pid} grace=${command.terminationGraceSeconds}s: ${message}`,
-      )
-    }
+    await dependencies.terminateProcessTree(
+      runningCommand.pid,
+      command.terminationGraceSeconds,
+    )
 
     const terminationTimeout = dependencies.delay(5000)
 
     try {
-      const finalCompletion = await Promise.race([
-        runningCommand.completion.then((res) => ({
-          type: 'completion' as const,
-          ...res,
-        })),
-        terminationTimeout.promise.then(() => ({ type: 'timeout' as const })),
+      const finalCompletion: RaceOutcome = await Promise.race([
+        runningCommand.completion.then(
+          (res): RaceOutcome => ({
+            type: 'completion',
+            ...res,
+          }),
+        ),
+        terminationTimeout.promise.then((): RaceOutcome => ({ type: 'timeout' })),
       ])
 
       if (finalCompletion.type === 'timeout') {

--- a/src/app/execute-retry/execute-attempt.ts
+++ b/src/app/execute-retry/execute-attempt.ts
@@ -45,16 +45,6 @@ export async function executeAttempt(
       exitCode: result.exitCode,
       stdout: result.stdout,
     }
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error)
-    core.error(`Attempt ${attempt} failed to execute command: ${message}`)
-
-    return {
-      attempt,
-      outcome: 'error',
-      exitCode: null,
-      stdout: '',
-    }
   } finally {
     cleanupSignalHandlers()
   }

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -174,18 +174,15 @@ describe('awaitAttemptOutcome', () => {
     expect(cancelTerminationTimeout).toHaveBeenCalled()
   })
 
-  it('logs error when terminateProcessTree fails and continues to wait for completion', async () => {
+  it('propagates error when terminateProcessTree fails', async () => {
     const command: CommandExecution = {
       command: 'sleep 10',
       timeoutSeconds: 1,
       terminationGraceSeconds: 5,
     }
 
-    let resolveCompletion: (value: { exitCode: number; stdout: string }) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => {
-        resolveCompletion = resolve
-      },
+      () => {},
     )
 
     const runningCommand: RunningCommand = {
@@ -216,72 +213,8 @@ describe('awaitAttemptOutcome', () => {
       dependencies,
     )
 
-    await new Promise(process.nextTick)
-
-    // Terminate tree failed, but we still expect to wait for the completion
-    expect(dependencies.terminateProcessTree).toHaveBeenCalled()
-
-    resolveCompletion?.({ exitCode: 1, stdout: 'failed\n' })
-
-    const result = await attemptPromise
-    expect(result).toEqual({
-      outcome: 'timeout',
-      exitCode: 1,
-      stdout: 'failed\n',
-    })
-  })
-
-  it('logs raw non-Error object when terminateProcessTree fails', async () => {
-    const command: CommandExecution = {
-      command: 'sleep 10',
-      timeoutSeconds: 1,
-      terminationGraceSeconds: 5,
-    }
-
-    let resolveCompletion: (value: { exitCode: number; stdout: string }) => void
-    const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => {
-        resolveCompletion = resolve
-      },
-    )
-
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
-
-    const dependencies = {
-      delay: vi
-        .fn()
-        .mockReturnValueOnce({
-          promise: Promise.resolve(), // Trigger initial timeout immediately
-          cancel: vi.fn(),
-        })
-        .mockReturnValueOnce({
-          promise: new Promise(() => {}), // Second delay never resolves
-          cancel: vi.fn(),
-        }),
-      terminateProcessTree: vi.fn().mockRejectedValue('String error message'),
-    }
-
-    const coreErrorSpy = vi.spyOn(core, 'error')
-
-    const attemptPromise = awaitAttemptOutcome(
-      command,
-      1,
-      runningCommand,
-      dependencies,
-    )
-    await new Promise(process.nextTick)
-
-    resolveCompletion?.({ exitCode: 1, stdout: 'failed\n' })
-
-    await attemptPromise
-
-    expect(coreErrorSpy).toHaveBeenCalledWith(
-      'Failed timeout termination pid=1234 grace=5s: String error message',
-    )
+    await expect(attemptPromise).rejects.toThrow('Kill failed')
+    expect(dependencies.terminateProcessTree).toHaveBeenCalledWith(1234, 5)
   })
 
   it('returns a safe outcome without exit code if termination fallback timeout triggers', async () => {

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -271,53 +271,35 @@ describe('executeRetry', () => {
     expect(result.attempts).toBe(3)
   })
 
-  it('treats synchronous errors in runCommand as error outcome and retries', async () => {
-    const runCommand = vi
-      .fn()
-      .mockImplementationOnce(() => {
-        throw new Error('spawn failed')
-      })
-      .mockReturnValueOnce(completed(0, '{"recovered":true}'))
+  it('escalates synchronous errors in runCommand', async () => {
+    const runCommand = vi.fn().mockImplementationOnce(() => {
+      throw new Error('spawn failed')
+    })
 
-    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
+    const attemptPromise = executeRetry(createRequest({ maxAttempts: 2 }), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
     })
 
-    expect(runCommand).toHaveBeenCalledTimes(2)
-    expect(result).toEqual({
-      attempts: 2,
-      finalExitCode: 0,
-      finalOutcome: 'success',
-      succeeded: true,
-      finalStdout: '{"recovered":true}',
-    })
+    await expect(attemptPromise).rejects.toThrow('spawn failed')
+    expect(runCommand).toHaveBeenCalledTimes(1)
   })
 
-  it('treats promise rejections in runCommand completion as error outcome and retries', async () => {
-    const runCommand = vi
-      .fn()
-      .mockReturnValueOnce({
-        pid: 101,
-        completion: Promise.reject(new Error('process crashed')),
-        isRunning: () => false,
-      })
-      .mockReturnValueOnce(completed(0, '{"recovered":true}'))
+  it('escalates promise rejections in runCommand completion', async () => {
+    const runCommand = vi.fn().mockReturnValueOnce({
+      pid: 101,
+      completion: Promise.reject(new Error('process crashed')),
+      isRunning: () => false,
+    })
 
-    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
+    const attemptPromise = executeRetry(createRequest({ maxAttempts: 2 }), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
     })
 
-    expect(runCommand).toHaveBeenCalledTimes(2)
-    expect(result).toEqual({
-      attempts: 2,
-      finalExitCode: 0,
-      finalOutcome: 'success',
-      succeeded: true,
-      finalStdout: '{"recovered":true}',
-    })
+    await expect(attemptPromise).rejects.toThrow('process crashed')
+    expect(runCommand).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Implementation of the plan to define explicit sum types for Promise race outcomes and establish a consistent failure contract.
* Extracted `RaceOutcome` into an explicit discriminated union type in `await-attempt-outcome.ts`.
* Removed the global catch around `execute-attempt.ts` and `dependencies.terminateProcessTree`.
* Replaced assertions in tests to expect explicit synchronous and asynchronous exception propagation instead of silent suppression and fallback retry logic.

---
*PR created automatically by Jules for task [3056977695666208957](https://jules.google.com/task/3056977695666208957) started by @akitorahayashi*