### PR TITLE
chore(docs): Emit librarian observer events

### DIFF
--- a/.jules/exchange/events/inconsistent_docs_hierarchy_librarian.md
+++ b/.jules/exchange/events/inconsistent_docs_hierarchy_librarian.md
@@ -1,0 +1,36 @@
+---
+label: "docs"
+created_at: "2026-03-25"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Problem
+
+Inconsistent structural hierarchy within the `docs/` directory; `usage.md` is placed as a flat file at the top level while other topic groupings (`architecture/`, `configuration/`) use directories.
+
+## Goal
+
+Relocate `usage.md` into an appropriate subdirectory (e.g., `docs/guides/usage.md` or `docs/procedures/usage.md`) to establish a stable structural foundation for topic groupings and eliminate flat accumulation.
+
+## Context
+
+Structural cohesion requires stable naming rules. Placing specialized documents at the top level of `docs/` alongside directories creates a mixed structural hierarchy that increases navigation entropy. Grouping usage examples under a specific capability-based subdirectory ensures that structural choices are deterministic and reduces lookup branching as the documentation scales.
+
+## Evidence
+
+- path: "docs/usage.md"
+  loc: "entire file"
+  note: "A flat file located at the top of docs/ while other topics use directories, hiding structural grouping intent."
+- path: "docs/architecture/"
+  loc: "directory"
+  note: "Uses a subdirectory for structural cohesion, contrasting with the flat usage.md."
+- path: "docs/configuration/"
+  loc: "directory"
+  note: "Uses a subdirectory for structural cohesion, contrasting with the flat usage.md."
+
+## Change Scope
+
+- `docs/usage.md`
+- `docs/README.md`
+- `README.md`

--- a/.jules/exchange/events/mixed_responsibilities_contributing_librarian.md
+++ b/.jules/exchange/events/mixed_responsibilities_contributing_librarian.md
@@ -1,0 +1,37 @@
+---
+label: "docs"
+created_at: "2026-03-25"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Problem
+
+`CONTRIBUTING.md` mixes distinct structural responsibilities, including procedural guides (Local Verification), structural specifications (Distribution Boundary), and policy definitions (Release Model).
+
+## Goal
+
+Separate the content of `CONTRIBUTING.md` into distinct canonical paths based on responsibility (e.g., procedures, architecture, and policy) to enforce document responsibility separation and reduce lookup branching.
+
+## Context
+
+One document must have one structural responsibility. Mixing procedure, specification, and policy in a single file hides placement intent and violates the principle that related documents should be structurally distinct. The "Distribution Boundary" conceptually belongs with architecture, while "Release Model" and "Local Verification" have distinct maintenance triggers and should reside in dedicated policy or procedure paths. This flat accumulation prevents users from choosing the right subtree from intent alone.
+
+## Evidence
+
+- path: "CONTRIBUTING.md"
+  loc: "lines 7-23"
+  note: "Contains 'Local Verification' procedural steps, which is distinct from architectural specifications."
+- path: "CONTRIBUTING.md"
+  loc: "lines 25-27"
+  note: "Contains 'Distribution Boundary' details, which acts as structural specification rather than contribution policy."
+- path: "CONTRIBUTING.md"
+  loc: "lines 29-32"
+  note: "Contains 'Release Model', representing repository policy."
+
+## Change Scope
+
+- `CONTRIBUTING.md`
+- `docs/architecture/boundary.md`
+- `docs/policy/release.md`
+- `docs/procedures/verification.md`

--- a/.jules/exchange/events/redundant_docs_index_librarian.md
+++ b/.jules/exchange/events/redundant_docs_index_librarian.md
@@ -1,0 +1,32 @@
+---
+label: "docs"
+created_at: "2026-03-25"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Problem
+
+`docs/README.md` functions as a flat index that enumerates files without providing routing criteria, duplicating the documentation index found in the root `README.md`.
+
+## Goal
+
+Eliminate the redundant index by relying on the root `README.md` as the primary documentation entry point, or update `docs/README.md` to provide structural routing guidance based on user intent rather than just listing files.
+
+## Context
+
+"Indexes that enumerate files without routing criteria" is a documented anti-pattern. Having multiple locations claiming authority for the documentation index increases navigation entropy. First-time readers are forced to choose between `README.md` and `docs/README.md` for orientation, which breaks the rule that there should be exactly one canonical path for orientation.
+
+## Evidence
+
+- path: "docs/README.md"
+  loc: "lines 1-14"
+  note: "Enumerates files with brief descriptions but lacks structural routing based on intent."
+- path: "README.md"
+  loc: "lines 22-26"
+  note: "Duplicates the documentation links found in docs/README.md, causing multiple locations to claim authority for the index."
+
+## Change Scope
+
+- `docs/README.md`
+- `README.md`


### PR DESCRIPTION
Analyzed documentation information architecture and identified three structural issues:
1. `docs/README.md` is a redundant flat index, duplicating `README.md`.
2. `CONTRIBUTING.md` mixes responsibilities (procedure, specification, policy).
3. `docs/usage.md` is a flat file accumulating alongside structural directories like `architecture/` and `configuration/`.

Emitted three event files in `.jules/exchange/events/` documenting these findings and proposed changes.

---
*PR created automatically by Jules for task [7780287941713607342](https://jules.google.com/task/7780287941713607342) started by @akitorahayashi*