### PR TITLE
Emit events for critical test coverage gaps

### DIFF
--- a/.jules/exchange/events/test_input_validation_gaps_cov.md
+++ b/.jules/exchange/events/test_input_validation_gaps_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Missing coverage for configuration input validation and edge cases, notably related to user-defined booleans and integer validation.
+
+Specifically:
+1. `src/action/read-inputs.ts` lines 78-79 and 108 are missing branch coverage. The error handling for parsing integers when an input isn't a valid integer and testing the 'off'/'no'/'0' boolean flag branch for `continueOnError` are uncovered.
+
+## Goal
+
+Add explicit unit tests to ensure that invalid user inputs (non-integers) fail fast and properly log the problem, and that valid explicit 'false' inputs for booleans operate as expected.
+
+## Context
+
+Configuration reading is the entry point for the Action. Uncovered error paths here can lead to confusing and hard-to-diagnose runtime problems for users configuring their CI pipelines. While basic coverage exists, specific error and branch behaviors (like non-integer handling and parsing specifically truthy/falsy fallback tokens) need to be formally asserted.
+
+## Evidence
+
+- path: "src/action/read-inputs.ts"
+  loc: "78-79, 108"
+  note: "Branch handling string regex match failure for parseInt wrapper, and explicit false-value normalization parsing are uncovered."
+
+## Change Scope
+
+- `src/action/read-inputs.ts`
+- `tests/action/read-inputs.test.ts`

--- a/.jules/exchange/events/uncovered_critical_error_handling_paths_cov.md
+++ b/.jules/exchange/events/uncovered_critical_error_handling_paths_cov.md
@@ -1,0 +1,44 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Some critical paths in error handling and specific fallback behaviors are not fully covered by tests, potentially masking regression risks.
+Specifically:
+1. `src/app/execute-retry/execute-attempt.ts` lines 44-45 missing test coverage for the condition where a successful attempt is returned without an exit code.
+2. `src/app/execute-retry/await-attempt-outcome.ts` lines 41-42 missing test coverage for the scenario where a command execution unexpectedly times out despite no timeout being defined.
+3. `src/app/execute-retry/execute-retry.ts` lines 30-33 and 75-79 missing test coverage for input validation (maxAttempts less than or equal to 0, or non-integer) and the scenario where execution completes without a final attempt result.
+
+## Goal
+
+Add tests to cover these crucial boundary, validation, and error-handling conditions to improve test coverage and safeguard against regression risks.
+
+## Context
+
+Test coverage signals regression risks. Critical decisions, data validations, and unexpected behaviors need robust assertions. Currently, the missing paths execute specific thrown errors for unexpected outcomes or validations, which must be tested to ensure the system behaves safely instead of silently failing or causing obscure state problems. High coverage metrics without execution in these specific lines present a "false safety" risk.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "44-45"
+  note: "Uncovered error throw when outcome is success but exitCode is null."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "41-42"
+  note: "Uncovered error throw for unexpected timeout when timeoutSeconds is undefined."
+- path: "src/app/execute-retry/index.ts"
+  loc: "30-33, 75-79"
+  note: "Uncovered initial validation and missing finalAttempt safety check logic."
+
+## Change Scope
+
+- `src/app/execute-retry/execute-attempt.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `src/app/execute-retry/index.ts`
+- `tests/app/execute-retry.test.ts`
+- `tests/app/await-attempt-outcome.test.ts`


### PR DESCRIPTION
This submission introduces two event files under `.jules/exchange/events/` highlighting critical areas of the codebase lacking test coverage. The event files document the context, evidence, and goals related to the missing test paths in `src/app/execute-retry/execute-attempt.ts`, `src/app/execute-retry/await-attempt-outcome.ts`, `src/app/execute-retry/index.ts`, and `src/action/read-inputs.ts`. These additions aim to support the 'cov' observer role by pinpointing areas where improved coverage can reduce regression risks.

---
*PR created automatically by Jules for task [2730337785549845947](https://jules.google.com/task/2730337785549845947) started by @akitorahayashi*