### PR TITLE
Add taxonomy events for naming inconsistencies

### DIFF
--- a/.jules/exchange/events/avoid_ambiguous_variable_names_taxonomy.md
+++ b/.jules/exchange/events/avoid_ambiguous_variable_names_taxonomy.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Variables related to handlers for process signals use ambiguous and informal naming (e.g., `onSigterm`, `onSigint`, `cleanupSignalHandlers`). This is inconsistent with the clear problem domain naming principle. Additionally, the term "handler" is vaguely used without a strong domain noun.
+
+## Goal
+
+Align signal handling variable and function names with clear domain-specific actions, explicitly identifying the lifecycle phase or bounded context.
+
+## Context
+
+In `src/app/execute-retry/execute-attempt.ts`, the function `registerCommandTerminationOnSignal` returns a teardown callback, which is locally bound to `cleanupSignalHandlers`. Using "cleanup" or "handlers" is generic. In `src/app/execute-retry/terminate-command-on-signal.ts`, the names `onSigterm`, `onSigint`, and `onSignal` are also generic event bindings rather than explicit domain actions. The observer contract explicitly calls out `generic 'handler'` as an anti-pattern.
+
+## Evidence
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "Line 28: const cleanupSignalHandlers = registerCommandTerminationOnSignal("
+  note: "Uses generic 'cleanup' and 'handlers' instead of a precise teardown action like 'unregisterSignalHooks' or 'removeSignalListeners'."
+- path: "src/app/execute-retry/terminate-command-on-signal.ts"
+  loc: "Line 29: const onSigterm = () => {"
+  note: "Uses generic 'onSigterm' event handler name."
+
+## Change Scope
+
+- `src/app/execute-retry/execute-attempt.ts`
+- `src/app/execute-retry/terminate-command-on-signal.ts`

--- a/.jules/exchange/events/inconsistent_naming_outcome_result_taxonomy.md
+++ b/.jules/exchange/events/inconsistent_naming_outcome_result_taxonomy.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The terms "outcome" and "result" are used ambiguously and occasionally interchangeably across the codebase, obscuring the boundary between an immediate physical completion state and a synthesized logical summary.
+
+## Goal
+
+Establish and enforce a canonical distinction: "Outcome" must refer strictly to the categorical classification of an execution attempt (e.g., success, error, timeout), while "Result" must refer to the structured envelope containing the outcome alongside associated data (e.g., attempt number, exit code, stdout).
+
+## Context
+
+In `src/domain/policy.ts`, `AttemptOutcome` is defined as `'success' | 'error' | 'timeout'`. However, `src/app/execute-retry/await-attempt-outcome.ts` defines an interface `AttemptExecutionOutcome` which is actually a structural result (containing `outcome`, `exitCode`, and `stdout`), blurring the line. Similarly, in `src/domain/result.ts`, `AttemptResult` contains an `outcome`, but `FinalResult` changes the property name to `finalOutcome`. This inconsistency causes cognitive friction and violates the "One Concept, One Preferred Term" principle.
+
+## Evidence
+
+- path: "src/domain/policy.ts"
+  loc: "Line 1: export type AttemptOutcome = 'success' | 'error' | 'timeout'"
+  note: "Defines 'Outcome' as a literal categorical state."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "Line 15: interface AttemptExecutionOutcome { outcome: AttemptOutcome; exitCode: number | null; stdout: string }"
+  note: "Uses 'Outcome' in the interface name for a structure that is conceptually a 'Result' (it even contains an 'outcome' property)."
+- path: "src/domain/result.ts"
+  loc: "Line 25: finalOutcome: 'success'"
+  note: "Prefixes 'Outcome' with 'final' inside 'FinalResult', making the property name shape inconsistent with 'AttemptResult' which just uses 'outcome'."
+
+## Change Scope
+
+- `src/domain/result.ts`
+- `src/domain/policy.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `src/app/execute-retry/index.ts`
+- `src/app/execute-retry/execute-attempt.ts`


### PR DESCRIPTION
Added two taxonomy events in `.jules/exchange/events/` identifying naming ambiguities in the repository:
1. `inconsistent_naming_outcome_result_taxonomy.md`: Highlights the ambiguous use of `Outcome` vs `Result`.
2. `avoid_ambiguous_variable_names_taxonomy.md`: Highlights the use of generic names like `handler`, `onSigterm`, and `cleanup` instead of precise domain actions.

---
*PR created automatically by Jules for task [9570379015774320542](https://jules.google.com/task/9570379015774320542) started by @akitorahayashi*