### PR TITLE
docs(events): emit typescripter observer events

### DIFF
--- a/.jules/exchange/events/inconsistent_failure_semantics_typescripter.md
+++ b/.jules/exchange/events/inconsistent_failure_semantics_typescripter.md
@@ -1,0 +1,33 @@
+---
+label: "bugs" # Must match a key in .jules/github-labels.json
+created_at: "2026-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`executeAttempt` mixes Result-style error handling (returning `AttemptResult` with `outcome: 'error'`) with uncaught thrown exceptions from `runShellCommand`. Errors that bypass the explicit `outcome` structure skip the retry loop logic entirely.
+
+## Goal
+
+Standardize failure semantics in the execution domain by adopting a consistent failure mode so all retry-eligible errors are returned as structured domain failures rather than silently bypassing retries as uncaught exceptions.
+
+## Context
+
+According to First Principles: "Failures are part of the API: pick a strategy and keep it consistent within a layer", and "Do async APIs have a consistent failure mode (throw vs Result vs undefined)...". `executeAttempt` implements a clear Result-style outcome return type, `AttemptResult`, with error and timeout states. However, `runShellCommand` (and `spawn`) can throw synchronously or asynchronously via events. The `try...finally` block in `executeAttempt` ensures signal handlers are cleaned up, but does not `catch` errors. This means standard exceptions skip the structured `outcome: 'error'` mapping and are bubbled up, completely defeating the retry policy for those failure modes.
+
+## Evidence
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "30-46"
+  note: "Mixes Result-style returns with potential uncaught exceptions from runShellCommand. No catch block is present to coerce generic throws into an error state."
+
+- path: "src/adapters/run-shell-command.ts"
+  loc: "30"
+  note: "runShellCommand can throw synchronously if the spawn wrapper encounters an issue (e.g. child.pid not defined)."
+
+## Change Scope
+
+- `src/app/execute-retry/execute-attempt.ts`
+- `src/adapters/run-shell-command.ts`

--- a/.jules/exchange/events/non_exhaustive_execution_outcome_typescripter.md
+++ b/.jules/exchange/events/non_exhaustive_execution_outcome_typescripter.md
@@ -1,0 +1,41 @@
+---
+label: "refacts" # Must match a key in .jules/github-labels.json
+created_at: "2026-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+`AttemptExecutionOutcome` uses a flat interface with nullable fields (`exitCode: number | null`) instead of a discriminated union to represent distinct states like success, error, and timeout. This requires call sites to perform defensive runtime checks.
+
+## Goal
+
+Model state as discriminated unions to make invalid states unrepresentable and enable the compiler to enforce exhaustive checks at boundaries.
+
+## Context
+
+First Principles state: "Make invalid states unrepresentable: model state as discriminated unions, not flags". And: "State modeled with discriminated unions (exhaustive switches; invalid states unrepresentable)". In `src/app/execute-retry/await-attempt-outcome.ts`, `AttemptExecutionOutcome` is:
+```typescript
+interface AttemptExecutionOutcome {
+  outcome: AttemptOutcome // 'success' | 'error' | 'timeout'
+  exitCode: number | null
+  stdout: string
+}
+```
+This forces the caller `executeAttempt` to perform defensive checks, such as verifying `result.exitCode === null` on a `'success'` outcome, because the type system cannot guarantee that a successful outcome always has a numeric exit code.
+
+## Evidence
+
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "15-19"
+  note: "Defines AttemptExecutionOutcome as a flat interface with nullable exitCode, allowing invalid states like outcome='success' and exitCode=null."
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "40-42"
+  note: "Call site in executeAttempt is forced to throw a runtime error if exitCode is null for a successful outcome."
+
+## Change Scope
+
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `src/app/execute-retry/execute-attempt.ts`

--- a/.jules/exchange/events/swallowed_errors_typescripter.md
+++ b/.jules/exchange/events/swallowed_errors_typescripter.md
@@ -1,0 +1,37 @@
+---
+label: "bugs" # Must match a key in .jules/github-labels.json
+created_at: "2026-03-25"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Empty `catch` blocks in standard error handling locations swallow failures silently. Certain fallback operations (such as stream reading and signal sending) omit explicit fallback logging, violating failure visibility principles and anti-patterns regarding swallowed exceptions.
+
+## Goal
+
+Ensure silent fallbacks are prohibited by logging, re-throwing, or returning explicitly from any caught error.
+
+## Context
+
+According to Design Conduct and Principles: "catch blocks that swallow errors or coerce them to any" are anti-patterns, and "Silent fallbacks are prohibited; any fallback is explicit, opt-in, and surfaced as a failure or a clearly logged, reviewed decision." In `runShellCommand.ts`, writing to standard output and error handles pipe failures with empty try-catch blocks. In `terminateProcessTree.ts`, signaling fallbacks silently swallow `process.kill` errors.
+
+## Evidence
+
+- path: "src/adapters/run-shell-command.ts"
+  loc: "36-39"
+  note: "An empty catch block swallows errors when stdout stream writes fail."
+
+- path: "src/adapters/run-shell-command.ts"
+  loc: "44-47"
+  note: "An empty catch block swallows errors when stderr stream writes fail."
+
+- path: "src/adapters/terminate-process-tree.ts"
+  loc: "15-19"
+  note: "An empty catch block swallows failures on `process.kill(-pid, signal)`, and another empty block follows for `process.kill(pid, signal)`."
+
+## Change Scope
+
+- `src/adapters/run-shell-command.ts`
+- `src/adapters/terminate-process-tree.ts`


### PR DESCRIPTION
Created 3 event files documenting TypeScript boundary, state modeling, and module issues found during analysis, strictly following the `typescripter` role directives and `.jules/schemas/event.md` schema constraints.

---
*PR created automatically by Jules for task [8918389247295447341](https://jules.google.com/task/8918389247295447341) started by @akitorahayashi*