### PR TITLE
Emit QA observer events for test suite

### DIFF
--- a/.jules/exchange/events/test_determinism_and_flakes_qa.md
+++ b/.jules/exchange/events/test_determinism_and_flakes_qa.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Some tests, such as `tests/adapters/terminate-process-tree.test.ts`, rely on arbitrary numeric timeouts and real child process spawned with `setInterval`/`sleep` commands for process isolation testing, making them non-deterministic and prone to flakes under load.
+
+## Goal
+
+Ensure that adapter tests testing side effects are deterministic, replacing sleep-based and arbitrary wait assumptions with deterministic IPC or mocked out streams.
+
+## Context
+
+The adapter test `terminate-process-tree.test.ts` literally sets up a real spawned process `timeout-forever.sh` and uses a fixed grace period (`GRACE_PERIOD_SECONDS = 0.05`) to test timeout cancellation. Using real time to test race conditions in `SIGTERM` and `SIGKILL` escalations on the process tree is a classic source of test flakiness. The execution time of these shell scripts and Node's event loop scheduling means under load, `0.05` seconds could elapse before the process is fully registered or before it handles the signal, leading to random test failures.
+
+## Evidence
+
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "16-36"
+  note: "Uses real bash script spawning with an arbitrary time period of 0.05 seconds to simulate an infinite process and check termination."
+
+- path: "tests/adapters/terminate-process-tree.test.ts"
+  loc: "50-76"
+  note: "Tests `SIGKILL` escalation by checking if `isAlive` correctly tracks process state across `sleep` statements in `ignore-term-then-exit.sh`, heavily relying on execution speed and real sleep intervals."
+
+## Change Scope
+
+- `tests/adapters/terminate-process-tree.test.ts`

--- a/.jules/exchange/events/test_failure_diagnosability_qa.md
+++ b/.jules/exchange/events/test_failure_diagnosability_qa.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The test file `tests/app/execute-retry.test.ts` uses massive setup mock functions that hide the details of each test.
+
+## Goal
+
+Provide clearer boundary and granular failure diagnostic when tests fail. Tests should use concise structures, allowing clear separation between arrange, act, and assert.
+
+## Context
+
+`executeRetry` is tested using an extremely elaborate helper `createRequest` and mock functions `createNeverDelay`. The tests for `executeRetry` span several assertions and tightly couple to the exact execution sequence of `delay` and `runCommand`. This large surface area for each test means if one fails, it takes more than a few minutes to localize the specific failure because the entire retry engine state machine is mocked in each test.
+
+## Evidence
+
+- path: "tests/app/execute-retry.test.ts"
+  loc: "55-104"
+  note: "Tests `executeRetry` by simulating timeouts through multiple mocking layers including `resolveCompletion` callbacks. The arrange phase is tangled."
+
+- path: "tests/app/execute-retry.test.ts"
+  loc: "106-166"
+  note: "Checks signal interruption by tracking `processOnceSpy`, triggering it manually, and flushing tasks via `vi.waitFor`, mingling async engine mechanics with pure policy logic."
+
+## Change Scope
+
+- `tests/app/execute-retry.test.ts`

--- a/.jules/exchange/events/test_structure_app_logic_vs_io_qa.md
+++ b/.jules/exchange/events/test_structure_app_logic_vs_io_qa.md
@@ -1,0 +1,35 @@
+---
+label: "tests"
+created_at: "2024-03-25"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Some tests mock I/O boundaries at an unhelpful abstraction level or test asynchronous execution by tightly coupling to `process` internals instead of providing clean control over time.
+
+## Goal
+
+Ensure that pure domain logic is tested without I/O and I/O integration tests have explicit timing and lifecycle boundaries without flakes or brittle process mocks.
+
+## Context
+
+The `awaitAttemptOutcome` function uses `Promise.race` for timeouts, and `tests/app/await-attempt-outcome.test.ts` injects a mocked delay function that directly resolves promises or blocks. While this avoids real time delays, the test logic gets somewhat tangled with the internal implementation of how delays work (the `cancel` and `promise` objects are tightly coupled to the test expectations).
+
+In `terminate-command-on-signal.test.ts`, `process.once`, `process.off`, and `process.exit` are spy-mocked. The tests execute real asynchronous code and manually advance promises (`await new Promise(process.nextTick)`). This creates a risk of brittle non-determinism, as node's event loop behavior is subtly relied upon for test sequencing rather than a deterministic test clock or explicit boundary interface.
+
+## Evidence
+
+- path: "tests/app/await-attempt-outcome.test.ts"
+  loc: "128-150"
+  note: "Tightly couples tests to the exact number of delay calls and their timing order, returning `new Promise(() => {})` to simulate a timeout not firing, making the test hard to read and sensitive to refactors."
+
+- path: "tests/app/terminate-command-on-signal.test.ts"
+  loc: "59-106"
+  note: "Uses `await new Promise(process.nextTick)` repeatedly to flush microtask queue because it depends on real JS event loop scheduling rather than a deterministic clock or fully synchronous pure domain boundary."
+
+## Change Scope
+
+- `tests/app/await-attempt-outcome.test.ts`
+- `tests/app/terminate-command-on-signal.test.ts`


### PR DESCRIPTION
Added high-signal findings regarding test structure and quality as event files in `.jules/exchange/events/` following the Observer contract.

---
*PR created automatically by Jules for task [14839799024615999238](https://jules.google.com/task/14839799024615999238) started by @akitorahayashi*