### PR TITLE
docs: add data architecture observer events

### DIFF
--- a/.jules/exchange/events/redundant_final_result_transport_dto_data_arch.md
+++ b/.jules/exchange/events/redundant_final_result_transport_dto_data_arch.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The domain layer contains a `FinalResult` type and a `toFinalResult` mapping function that are explicitly designed to match GitHub Action transport outputs, violating Boundary Sovereignty.
+
+## Goal
+
+Remove `FinalResult` from the domain layer. The domain should yield the core `AttemptResult` representing the execution outcome, and the action layer (`emitOutputs` and `index.ts`) should derive the action-specific output formats.
+
+## Context
+
+First Principles state that domain models should remain independent of transport or UI concerns. `FinalResult` renames fields to `finalExitCode` and `finalStdout`, and adds a derived `succeeded` boolean purely to satisfy `action.yml` outputs. This couples the core domain to GitHub Action specifics.
+
+## Evidence
+
+- path: "src/domain/result.ts"
+  loc: "FinalResult"
+  note: "Defines a type with 'final'-prefixed fields and a 'succeeded' boolean that mirror GitHub Action outputs."
+- path: "src/domain/result.ts"
+  loc: "toFinalResult"
+  note: "Performs an inefficient transformation solely to rename fields and derive 'succeeded'."
+- path: "src/action/emit-outputs.ts"
+  loc: "emitOutputs"
+  note: "Consumes the domain's FinalResult rather than receiving the domain model and performing the transport mapping itself."
+
+## Change Scope
+
+- `src/domain/result.ts`
+- `src/action/emit-outputs.ts`
+- `src/index.ts`
+- `src/app/execute-retry/index.ts`

--- a/.jules/exchange/events/redundant_validation_max_attempts_data_arch.md
+++ b/.jules/exchange/events/redundant_validation_max_attempts_data_arch.md
@@ -1,0 +1,31 @@
+---
+label: "refacts"
+created_at: "2026-03-25"
+author_role: "data_arch"
+confidence: "medium"
+---
+
+## Problem
+
+`maxAttempts` is validated in both `readInputs` and `executeRetry`, blurring the boundary of where invariants are enforced and representing the same constraint in multiple places.
+
+## Goal
+
+Rely on `readInputs` to enforce parameter boundaries (transport/entrypoint layer) and possibly represent `maxAttempts` using a refined type, removing the redundant `if (!Number.isInteger(request.maxAttempts) || request.maxAttempts <= 0)` runtime panic in the core application logic.
+
+## Context
+
+According to First Principles, invariants should be enforced at the boundary. `readInputs` appropriately calls `readRequiredInteger('max_attempts', { minimum: 1 })`. The inner `executeRetry` should receive this explicitly trusted fact rather than validating it defensively again.
+
+## Evidence
+
+- path: "src/action/read-inputs.ts"
+  loc: "readInputs (line 20)"
+  note: "Validates `maxAttempts` with a minimum of 1."
+- path: "src/app/execute-retry/index.ts"
+  loc: "executeRetry (line 29)"
+  note: "Defensively checks `!Number.isInteger(request.maxAttempts) || request.maxAttempts <= 0`."
+
+## Change Scope
+
+- `src/app/execute-retry/index.ts`


### PR DESCRIPTION
Adds two events identified by the data architecture role.

---
*PR created automatically by Jules for task [11977197748717654706](https://jules.google.com/task/11977197748717654706) started by @akitorahayashi*