### PR TITLE
refactor: align signal handling domain naming

### DIFF
--- a/src/app/execute-retry/execute-attempt.ts
+++ b/src/app/execute-retry/execute-attempt.ts
@@ -21,7 +21,7 @@ export async function executeAttempt(
 
   let runningCommand: RunningCommand | undefined
 
-  const cleanupSignalHandlers = registerCommandTerminationOnSignal({
+  const unregisterSignalHooks = registerCommandTerminationOnSignal({
     getRunningCommand: () => runningCommand,
     terminationGraceSeconds: command.terminationGraceSeconds,
     terminateProcessTree: dependencies.terminateProcessTree,
@@ -68,6 +68,6 @@ export async function executeAttempt(
       stdout: result.stdout,
     }
   } finally {
-    cleanupSignalHandlers()
+    unregisterSignalHooks()
   }
 }

--- a/src/app/execute-retry/terminate-command-on-signal.ts
+++ b/src/app/execute-retry/terminate-command-on-signal.ts
@@ -10,7 +10,7 @@ interface RegisterCommandTerminationOnSignalParams {
 export function registerCommandTerminationOnSignal(
   params: RegisterCommandTerminationOnSignalParams,
 ): () => void {
-  const onSignal = async (signal: NodeJS.Signals): Promise<void> => {
+  const terminateCommandAndProcessTree = async (signal: NodeJS.Signals): Promise<void> => {
     const runningCommand = params.getRunningCommand()
     if (!runningCommand?.isRunning()) {
       return
@@ -31,8 +31,8 @@ export function registerCommandTerminationOnSignal(
     }
   }
 
-  const onSigterm = () => {
-    onSignal('SIGTERM')
+  const handleSigtermTermination = () => {
+    terminateCommandAndProcessTree('SIGTERM')
       .then(() => {
         process.exit(0)
       })
@@ -43,8 +43,8 @@ export function registerCommandTerminationOnSignal(
       })
   }
 
-  const onSigint = () => {
-    onSignal('SIGINT')
+  const handleSigintTermination = () => {
+    terminateCommandAndProcessTree('SIGINT')
       .then(() => {
         process.exit(0)
       })
@@ -55,11 +55,11 @@ export function registerCommandTerminationOnSignal(
       })
   }
 
-  process.once('SIGTERM', onSigterm)
-  process.once('SIGINT', onSigint)
+  process.once('SIGTERM', handleSigtermTermination)
+  process.once('SIGINT', handleSigintTermination)
 
   return () => {
-    process.off('SIGTERM', onSigterm)
-    process.off('SIGINT', onSigint)
+    process.off('SIGTERM', handleSigtermTermination)
+    process.off('SIGINT', handleSigintTermination)
   }
 }

--- a/src/app/execute-retry/terminate-command-on-signal.ts
+++ b/src/app/execute-retry/terminate-command-on-signal.ts
@@ -10,7 +10,9 @@ interface RegisterCommandTerminationOnSignalParams {
 export function registerCommandTerminationOnSignal(
   params: RegisterCommandTerminationOnSignalParams,
 ): () => void {
-  const terminateCommandAndProcessTree = async (signal: NodeJS.Signals): Promise<void> => {
+  const terminateCommandAndProcessTree = async (
+    signal: NodeJS.Signals,
+  ): Promise<void> => {
     const runningCommand = params.getRunningCommand()
     if (!runningCommand?.isRunning()) {
       return


### PR DESCRIPTION
Implements refactoring of signal handler naming in execute-attempt.ts and terminate-command-on-signal.ts to avoid ambiguous terminology and use explicit domain actions instead.

Fixes issue as described in exchange lane requirements.

---
*PR created automatically by Jules for task [7755381370544685755](https://jules.google.com/task/7755381370544685755) started by @akitorahayashi*