### PR TITLE
docs: Split CONTRIBUTING.md responsibilities into specialized paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,35 +4,10 @@
 
 `retry` is a single-action repository. The active runtime surface is the GitHub Action contract in `action.yml` and the TypeScript boundaries under `src/`.
 
-## Local Verification
+## Documentation Index
 
-`just` is the canonical local entrypoint for repository tasks.
+Detailed documentation is organized into specialized paths based on structural responsibility:
 
-The repository-owned verification and maintenance recipes are:
-
-- `just fix`: runs `npm run format` and `npm run lint:fix`
-- `just check`: runs `npm run format:check`, `npm run lint`, and `npm run typecheck`
-- `just test`: runs `npm test`
-- `just coverage`: resets `coverage/` and runs `npm run test:coverage`
-- `just clean`: removes repository-local generated artifacts under `.tmp`, `coverage`, and `node_modules`
-
-`package.json` retains the atomic npm scripts behind these recipes:
-
-- `npm run format`
-- `npm run format:check`
-- `npm run lint`
-- `npm run lint:fix`
-- `npm test`
-- `npm run test:coverage`
-- `npm run typecheck`
-- `npm run package`
-
-## Distribution Boundary
-
-`dist/` is committed because GitHub Actions executes repository contents directly from the tagged revision. Normal development changes do not update `dist/`.
-Release automation on `main` runs `npm run package`, commits `dist/` when changed, and then creates release tags.
-
-## Release Model
-
-The repository versions one action. Consumer-facing tags follow `vX.Y.Z`, and the moving major tag for workflows is `v1`.
-Release automation is manually dispatched with an `X.Y.Z` input, validates it on `main`, creates `vX.Y.Z`, moves `v1`, and publishes the GitHub Release.
+- [Local Verification](docs/procedures/verification.md): Procedural guides for local verification and testing.
+- [Distribution Boundary](docs/architecture/boundary.md): Structural specifications regarding repository content distribution.
+- [Release Model](docs/policy/release.md): Policy definitions and models for releasing new versions.

--- a/docs/architecture/boundary.md
+++ b/docs/architecture/boundary.md
@@ -43,3 +43,8 @@ The action fails explicitly when:
 - attempts are exhausted and `continue_on_error` is not enabled
 
 No silent fallback paths are used.
+
+## Distribution Boundary
+
+`dist/` is committed because GitHub Actions executes repository contents directly from the tagged revision. Normal development changes do not update `dist/`.
+Release automation on `main` runs `npm run package`, commits `dist/` when changed, and then creates release tags.

--- a/docs/policy/release.md
+++ b/docs/policy/release.md
@@ -1,0 +1,6 @@
+# Release Policy
+
+## Release Model
+
+The repository versions one action. Consumer-facing tags follow `vX.Y.Z`, and the moving major tag for workflows is `v1`.
+Release automation is manually dispatched with an `X.Y.Z` input, validates it on `main`, creates `vX.Y.Z`, moves `v1`, and publishes the GitHub Release.

--- a/docs/procedures/verification.md
+++ b/docs/procedures/verification.md
@@ -1,0 +1,24 @@
+# Verification
+
+## Local Verification
+
+`just` is the canonical local entrypoint for repository tasks.
+
+The repository-owned verification and maintenance recipes are:
+
+- `just fix`: runs `npm run format` and `npm run lint:fix`
+- `just check`: runs `npm run format:check`, `npm run lint`, and `npm run typecheck`
+- `just test`: runs `npm test`
+- `just coverage`: resets `coverage/` and runs `npm run test:coverage`
+- `just clean`: removes repository-local generated artifacts under `.tmp`, `coverage`, and `node_modules`
+
+`package.json` retains the atomic npm scripts behind these recipes:
+
+- `npm run format`
+- `npm run format:check`
+- `npm run lint`
+- `npm run lint:fix`
+- `npm test`
+- `npm run test:coverage`
+- `npm run typecheck`
+- `npm run package`


### PR DESCRIPTION
Separated the mixed content of `CONTRIBUTING.md` into distinct canonical paths based on structural responsibility (procedures, architecture, and policy) to enforce document responsibility separation and reduce lookup branching.

- Moved "Distribution Boundary" to `docs/architecture/boundary.md`.
- Moved "Release Model" to `docs/policy/release.md`.
- Moved "Local Verification" to `docs/procedures/verification.md`.
- Simplified `CONTRIBUTING.md` to serve as an index referencing these specialized paths.

---
*PR created automatically by Jules for task [3112383532163791226](https://jules.google.com/task/3112383532163791226) started by @akitorahayashi*