### PR TITLE
refactor: Consolidate input validation boundaries

### DIFF
--- a/src/app/execute-retry/index.ts
+++ b/src/app/execute-retry/index.ts
@@ -26,12 +26,6 @@ export async function executeRetry(
   request: ExecuteRetryRequest,
   dependencies: ExecuteRetryDependencies = executeRetryDependencies,
 ): Promise<FinalResult> {
-  if (!Number.isInteger(request.maxAttempts) || request.maxAttempts <= 0) {
-    throw new Error(
-      `ExecuteRetryRequest.maxAttempts must be a positive integer, but received: ${request.maxAttempts}`,
-    )
-  }
-
   const { policy, schedule } = request
 
   let finalAttempt: AttemptResult | undefined

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -140,7 +140,9 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow("Input 'max_attempts' must be an integer.")
+    expect(() => readInputs()).toThrow(
+      "Input 'max_attempts' must be an integer.",
+    )
   })
 
   it.each([
@@ -152,7 +154,10 @@ describe('readInputs', () => {
     { token: 'true', expected: true },
     { token: 'yes', expected: true },
     { token: 'on', expected: true },
-  ])('normalizes boolean token "$token" to $expected', ({ token, expected }) => {
+  ])('normalizes boolean token "$token" to $expected', ({
+    token,
+    expected,
+  }) => {
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
         case 'command':

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -135,6 +135,8 @@ describe('readInputs', () => {
           return 'echo ok'
         case 'max_attempts':
           return '3.5'
+        case 'timeout_seconds':
+          return '10.2'
         default:
           return ''
       }
@@ -142,6 +144,23 @@ describe('readInputs', () => {
 
     expect(() => readInputs()).toThrow(
       "Input 'max_attempts' must be an integer.",
+    )
+
+    mockedGetInput.mockImplementation((name: string) => {
+      switch (name) {
+        case 'command':
+          return 'echo ok'
+        case 'max_attempts':
+          return '3'
+        case 'timeout_seconds':
+          return 'abc'
+        default:
+          return ''
+      }
+    })
+
+    expect(() => readInputs()).toThrow(
+      "Input 'timeout_seconds' must be an integer.",
     )
   })
 
@@ -154,6 +173,9 @@ describe('readInputs', () => {
     { token: 'true', expected: true },
     { token: 'yes', expected: true },
     { token: 'on', expected: true },
+    { token: 'True', expected: true },
+    { token: 'YES', expected: true },
+    { token: 'Off', expected: false },
   ])('normalizes boolean token "$token" to $expected', ({
     token,
     expected,

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -128,6 +128,48 @@ describe('readInputs', () => {
     expect(() => readInputs()).toThrow("Input 'max_attempts' must be >= 1.")
   })
 
+  it('throws when numeric value is not an integer', () => {
+    mockedGetInput.mockImplementation((name: string) => {
+      switch (name) {
+        case 'command':
+          return 'echo ok'
+        case 'max_attempts':
+          return '3.5'
+        default:
+          return ''
+      }
+    })
+
+    expect(() => readInputs()).toThrow("Input 'max_attempts' must be an integer.")
+  })
+
+  it.each([
+    { token: '0', expected: false },
+    { token: 'false', expected: false },
+    { token: 'no', expected: false },
+    { token: 'off', expected: false },
+    { token: '1', expected: true },
+    { token: 'true', expected: true },
+    { token: 'yes', expected: true },
+    { token: 'on', expected: true },
+  ])('normalizes boolean token "$token" to $expected', ({ token, expected }) => {
+    mockedGetInput.mockImplementation((name: string) => {
+      switch (name) {
+        case 'command':
+          return 'echo ok'
+        case 'max_attempts':
+          return '1'
+        case 'continue_on_error':
+          return token
+        default:
+          return ''
+      }
+    })
+
+    const result = readInputs()
+    expect(result.continueOnError).toBe(expected)
+  })
+
   it('throws when continue_on_error uses invalid boolean token', () => {
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -162,6 +162,23 @@ describe('readInputs', () => {
     expect(() => readInputs()).toThrow(
       "Input 'timeout_seconds' must be an integer.",
     )
+
+    mockedGetInput.mockImplementation((name: string) => {
+      switch (name) {
+        case 'command':
+          return 'echo ok'
+        case 'max_attempts':
+          return '3'
+        case 'retry_delay_seconds':
+          return '1.5'
+        default:
+          return ''
+      }
+    })
+
+    expect(() => readInputs()).toThrow(
+      "Input 'retry_delay_seconds' must be an integer.",
+    )
   })
 
   it.each([


### PR DESCRIPTION
Consolidated parameter input validation at the transport/entrypoint layer (`readInputs`) ensuring invalid inputs fail fast. Removed redundant runtime panic checks for `maxAttempts` in the core application logic to establish a trusted boundary. Added explicit test coverage for these validations.

---
*PR created automatically by Jules for task [14799172660069356730](https://jules.google.com/task/14799172660069356730) started by @akitorahayashi*