### PR TITLE
test: add coverage for critical error handling paths

### DIFF
--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -59,7 +59,9 @@ describe('awaitAttemptOutcome', () => {
     // it expects or just skips the completion mapping.
     // Wait, the easiest way is to mock `completionPromise` inside the function?
     // We cannot. But we CAN mock `runningCommand.completion.then` directly!
+    // We assign vi.fn() to the 'then' property and disable the linter check
     runningCommand.completion = {
+      // biome-ignore lint/suspicious/noThenProperty: we are intentionally mocking a Promise
       then: vi.fn().mockResolvedValue({ type: 'timeout' }),
     } as unknown as Promise<{ exitCode: number | null; stdout: string }>
     const dependencies = {

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -52,18 +52,16 @@ describe('awaitAttemptOutcome', () => {
       completion: Promise.resolve({ exitCode: null, stdout: '' }),
     }
 
-    // Since `runningCommand.completion.then` in `awaitAttemptOutcome` forcibly
-    // maps the result to `{ type: 'completion', exitCode, stdout }`, we cannot
-    // easily return `{ type: 'timeout' }` from `completionPromise` just by
-    // controlling `runningCommand.completion`.
-    // However, we can mock `Promise.prototype.then` temporarily or somehow
-    // intercept `runningCommand.completion.then`.
-    // Better yet, mock `runningCommand.completion` object itself to have a custom `then` method.
+    // To simulate completion resolving to a timeout outcome natively,
+    // we use `Object.defineProperty` or `vi.spyOn` on the promise `then`.
+    // But since it's a native promise, we can instead return an object
+    // that mimics a promise and directly invokes the callback with what
+    // it expects or just skips the completion mapping.
+    // Wait, the easiest way is to mock `completionPromise` inside the function?
+    // We cannot. But we CAN mock `runningCommand.completion.then` directly!
     runningCommand.completion = {
-      then: (onfulfilled: (value: any) => any) => {
-        return Promise.resolve(onfulfilled ? { type: 'timeout' } : undefined)
-      }
-    } as any
+      then: vi.fn().mockResolvedValue({ type: 'timeout' }),
+    } as unknown as Promise<{ exitCode: number | null; stdout: string }>
     const dependencies = {
       delay: vi.fn(),
       terminateProcessTree: vi.fn(),

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -52,14 +52,9 @@ describe('awaitAttemptOutcome', () => {
       completion: Promise.resolve({ exitCode: null, stdout: '' }),
     }
 
-    // To simulate completion resolving to a timeout outcome natively,
-    // we use `Object.defineProperty` or `vi.spyOn` on the promise `then`.
-    // But since it's a native promise, we can instead return an object
-    // that mimics a promise and directly invokes the callback with what
-    // it expects or just skips the completion mapping.
-    // Wait, the easiest way is to mock `completionPromise` inside the function?
-    // We cannot. But we CAN mock `runningCommand.completion.then` directly!
-    // We assign vi.fn() to the 'then' property and disable the linter check
+    // Replace completion with a thenable that resolves to a timeout outcome.
+    // This isolates the defensive branch where timeoutSeconds is undefined but
+    // the completion path unexpectedly reports a timeout.
     runningCommand.completion = {
       // biome-ignore lint/suspicious/noThenProperty: we are intentionally mocking a Promise
       then: vi.fn().mockResolvedValue({ type: 'timeout' }),
@@ -121,7 +116,7 @@ describe('awaitAttemptOutcome', () => {
     const cancelTimeout = vi.fn()
     const dependencies = {
       delay: vi.fn().mockReturnValue({
-        promise: new Promise(() => {}), // Never resolves so completion wins
+        promise: new Promise(() => { }), // Never resolves so completion wins
         cancel: cancelTimeout,
       }),
       terminateProcessTree: vi.fn(),
@@ -182,7 +177,7 @@ describe('awaitAttemptOutcome', () => {
         })
         .mockReturnValueOnce({
           // Second delay is the 5000ms termination timeout
-          promise: new Promise(() => {}), // Never resolves so completion wins
+          promise: new Promise(() => { }), // Never resolves so completion wins
           cancel: cancelTerminationTimeout,
         }),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
@@ -226,7 +221,7 @@ describe('awaitAttemptOutcome', () => {
     }
 
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      () => {},
+      () => { },
     )
 
     const runningCommand: RunningCommand = {
@@ -244,7 +239,7 @@ describe('awaitAttemptOutcome', () => {
           cancel: cancelTimeout,
         })
         .mockReturnValueOnce({
-          promise: new Promise(() => {}), // Second delay never resolves
+          promise: new Promise(() => { }), // Second delay never resolves
           cancel: vi.fn(),
         }),
       terminateProcessTree: vi.fn().mockRejectedValue(new Error('Kill failed')),
@@ -273,7 +268,7 @@ describe('awaitAttemptOutcome', () => {
     }
 
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      () => {},
+      () => { },
     )
 
     const runningCommand: RunningCommand = {
@@ -290,7 +285,7 @@ describe('awaitAttemptOutcome', () => {
           cancel: vi.fn(),
         })
         .mockReturnValueOnce({
-          promise: new Promise(() => {}), // Second delay never resolves
+          promise: new Promise(() => { }), // Second delay never resolves
           cancel: vi.fn(),
         }),
       terminateProcessTree: vi.fn().mockRejectedValue('String error message'),
@@ -318,7 +313,7 @@ describe('awaitAttemptOutcome', () => {
     const runningCommand: RunningCommand = {
       pid: 1234,
       isRunning: () => true,
-      completion: new Promise(() => {}), // Never completes
+      completion: new Promise(() => { }), // Never completes
     }
 
     const dependencies = {

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -39,6 +39,42 @@ describe('awaitAttemptOutcome', () => {
     expect(dependencies.delay).not.toHaveBeenCalled()
   })
 
+  it('throws error when process unexpectedly times out despite timeoutSeconds being undefined', async () => {
+    const command: CommandSpec = {
+      command: 'echo "test"',
+      shell: 'bash',
+      timeoutSeconds: undefined,
+      terminationGraceSeconds: 5,
+    }
+    const runningCommand: RunningCommand = {
+      pid: 1234,
+      isRunning: () => true,
+      completion: Promise.resolve({ exitCode: null, stdout: '' }),
+    }
+
+    // Since `runningCommand.completion.then` in `awaitAttemptOutcome` forcibly
+    // maps the result to `{ type: 'completion', exitCode, stdout }`, we cannot
+    // easily return `{ type: 'timeout' }` from `completionPromise` just by
+    // controlling `runningCommand.completion`.
+    // However, we can mock `Promise.prototype.then` temporarily or somehow
+    // intercept `runningCommand.completion.then`.
+    // Better yet, mock `runningCommand.completion` object itself to have a custom `then` method.
+    runningCommand.completion = {
+      then: (onfulfilled: (value: any) => any) => {
+        return Promise.resolve(onfulfilled ? { type: 'timeout' } : undefined)
+      }
+    } as any
+    const dependencies = {
+      delay: vi.fn(),
+      terminateProcessTree: vi.fn(),
+    }
+
+    await expect(
+      awaitAttemptOutcome(command, 1, runningCommand, dependencies),
+    ).rejects.toThrow('Unexpected timeout when timeout is undefined')
+    expect(dependencies.delay).not.toHaveBeenCalled()
+  })
+
   it('returns error when process completes with non-zero exit code without timeout', async () => {
     const command: CommandSpec = {
       command: 'exit 1',

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -116,7 +116,7 @@ describe('awaitAttemptOutcome', () => {
     const cancelTimeout = vi.fn()
     const dependencies = {
       delay: vi.fn().mockReturnValue({
-        promise: new Promise(() => { }), // Never resolves so completion wins
+        promise: new Promise(() => {}), // Never resolves so completion wins
         cancel: cancelTimeout,
       }),
       terminateProcessTree: vi.fn(),
@@ -177,7 +177,7 @@ describe('awaitAttemptOutcome', () => {
         })
         .mockReturnValueOnce({
           // Second delay is the 5000ms termination timeout
-          promise: new Promise(() => { }), // Never resolves so completion wins
+          promise: new Promise(() => {}), // Never resolves so completion wins
           cancel: cancelTerminationTimeout,
         }),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
@@ -221,7 +221,7 @@ describe('awaitAttemptOutcome', () => {
     }
 
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      () => { },
+      () => {},
     )
 
     const runningCommand: RunningCommand = {
@@ -239,7 +239,7 @@ describe('awaitAttemptOutcome', () => {
           cancel: cancelTimeout,
         })
         .mockReturnValueOnce({
-          promise: new Promise(() => { }), // Second delay never resolves
+          promise: new Promise(() => {}), // Second delay never resolves
           cancel: vi.fn(),
         }),
       terminateProcessTree: vi.fn().mockRejectedValue(new Error('Kill failed')),
@@ -268,7 +268,7 @@ describe('awaitAttemptOutcome', () => {
     }
 
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      () => { },
+      () => {},
     )
 
     const runningCommand: RunningCommand = {
@@ -285,7 +285,7 @@ describe('awaitAttemptOutcome', () => {
           cancel: vi.fn(),
         })
         .mockReturnValueOnce({
-          promise: new Promise(() => { }), // Second delay never resolves
+          promise: new Promise(() => {}), // Second delay never resolves
           cancel: vi.fn(),
         }),
       terminateProcessTree: vi.fn().mockRejectedValue('String error message'),
@@ -313,7 +313,7 @@ describe('awaitAttemptOutcome', () => {
     const runningCommand: RunningCommand = {
       pid: 1234,
       isRunning: () => true,
-      completion: new Promise(() => { }), // Never completes
+      completion: new Promise(() => {}), // Never completes
     }
 
     const dependencies = {

--- a/tests/app/execute-attempt.test.ts
+++ b/tests/app/execute-attempt.test.ts
@@ -5,13 +5,16 @@ import type { CommandSpec } from '../../src/domain/command'
 import * as awaitAttemptOutcomeModule from '../../src/app/execute-retry/await-attempt-outcome'
 
 // Mock awaitAttemptOutcome to simulate a success but with a null exit code
-vi.mock('../../src/app/execute-retry/await-attempt-outcome', async (importOriginal) => {
-  const actual = await importOriginal<typeof awaitAttemptOutcomeModule>()
-  return {
-    ...actual,
-    awaitAttemptOutcome: vi.fn(),
-  }
-})
+vi.mock(
+  '../../src/app/execute-retry/await-attempt-outcome',
+  async (importOriginal) => {
+    const actual = await importOriginal<typeof awaitAttemptOutcomeModule>()
+    return {
+      ...actual,
+      awaitAttemptOutcome: vi.fn(),
+    }
+  },
+)
 
 describe('executeAttempt', () => {
   beforeEach(() => {
@@ -42,8 +45,8 @@ describe('executeAttempt', () => {
       stdout: '',
     })
 
-    await expect(
-      executeAttempt(command, 1, dependencies)
-    ).rejects.toThrow('Successful attempt must include a numeric exit code.')
+    await expect(executeAttempt(command, 1, dependencies)).rejects.toThrow(
+      'Successful attempt must include a numeric exit code.',
+    )
   })
 })

--- a/tests/app/execute-attempt.test.ts
+++ b/tests/app/execute-attempt.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { executeAttempt } from '../../src/app/execute-retry/execute-attempt'
+import type { ExecuteRetryDependencies } from '../../src/app/execute-retry/execute-retry-dependencies'
+import type { CommandSpec } from '../../src/domain/command'
+import * as awaitAttemptOutcomeModule from '../../src/app/execute-retry/await-attempt-outcome'
+
+// Mock awaitAttemptOutcome to simulate a success but with a null exit code
+vi.mock('../../src/app/execute-retry/await-attempt-outcome', async (importOriginal) => {
+  const actual = await importOriginal<typeof awaitAttemptOutcomeModule>()
+  return {
+    ...actual,
+    awaitAttemptOutcome: vi.fn(),
+  }
+})
+
+describe('executeAttempt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws an error when attempt succeeds but exitCode is null', async () => {
+    const command: CommandSpec = {
+      command: 'echo "test"',
+      shell: 'bash',
+      timeoutSeconds: undefined,
+      terminationGraceSeconds: 5,
+    }
+
+    const dependencies: ExecuteRetryDependencies = {
+      runCommand: vi.fn().mockReturnValue({
+        pid: 1234,
+        completion: Promise.resolve({ exitCode: null, stdout: '' }),
+        isRunning: () => false,
+      }),
+      delay: vi.fn(),
+      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+    }
+
+    vi.mocked(awaitAttemptOutcomeModule.awaitAttemptOutcome).mockResolvedValue({
+      outcome: 'success',
+      exitCode: null,
+      stdout: '',
+    })
+
+    await expect(
+      executeAttempt(command, 1, dependencies)
+    ).rejects.toThrow('Successful attempt must include a numeric exit code.')
+  })
+})

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -59,6 +59,42 @@ function createNeverDelay() {
 }
 
 describe('executeRetry', () => {
+  it('throws an error when finalAttempt is missing', async () => {
+    // We mock the maxAttempts property so it passes the integer validation
+    // but the loop does not run. We need to mock it returning > 0 for validation
+    // and > 0 for `request.maxAttempts > 0` check.
+    const request = createRequest({ maxAttempts: 1 })
+    Object.defineProperty(request, 'maxAttempts', {
+      get: vi.fn()
+        .mockReturnValueOnce(1) // Number.isInteger check
+        .mockReturnValueOnce(1) // <= 0 check
+        .mockReturnValueOnce(0), // for loop condition check
+    })
+
+    await expect(
+      executeRetry(request, {
+        runCommand: vi.fn(),
+        delay: vi.fn(),
+        terminateProcessTree: vi.fn(),
+      }),
+    ).rejects.toThrow('Retry execution did not produce an attempt result.')
+  })
+
+  it.each([0, -1, 1.5])(
+    'throws an error when maxAttempts is invalid (%s)',
+    async (invalidMaxAttempts) => {
+      await expect(
+        executeRetry(createRequest({ maxAttempts: invalidMaxAttempts }), {
+          runCommand: vi.fn(),
+          delay: vi.fn(),
+          terminateProcessTree: vi.fn(),
+        }),
+      ).rejects.toThrow(
+        `ExecuteRetryRequest.maxAttempts must be a positive integer, but received: ${invalidMaxAttempts}`,
+      )
+    },
+  )
+
   it('returns timeout and terminates process tree when timeout wins', async () => {
     let resolveCompletion!: (value: {
       exitCode: number | null

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -53,16 +53,16 @@ function completed(exitCode: number | null, stdout = ''): RunningCommand {
 
 function createNeverDelay() {
   return {
-    promise: new Promise<void>(() => {}),
+    promise: new Promise<void>(() => { }),
     cancel: vi.fn(),
   }
 }
 
 describe('executeRetry', () => {
   it('throws an error when finalAttempt is missing', async () => {
-    // We mock the maxAttempts property so it passes the integer validation
-    // but the loop does not run. We need to mock it returning > 0 for validation
-    // and > 0 for `request.maxAttempts > 0` check.
+    // Control maxAttempts reads to pass request validation and then force the
+    // retry loop condition to short-circuit, exercising the missing-finalAttempt
+    // defensive error path.
     const request = createRequest({ maxAttempts: 1 })
     Object.defineProperty(request, 'maxAttempts', {
       get: vi

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -53,7 +53,7 @@ function completed(exitCode: number | null, stdout = ''): RunningCommand {
 
 function createNeverDelay() {
   return {
-    promise: new Promise<void>(() => { }),
+    promise: new Promise<void>(() => {}),
     cancel: vi.fn(),
   }
 }

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -65,7 +65,8 @@ describe('executeRetry', () => {
     // and > 0 for `request.maxAttempts > 0` check.
     const request = createRequest({ maxAttempts: 1 })
     Object.defineProperty(request, 'maxAttempts', {
-      get: vi.fn()
+      get: vi
+        .fn()
         .mockReturnValueOnce(1) // Number.isInteger check
         .mockReturnValueOnce(1) // <= 0 check
         .mockReturnValueOnce(0), // for loop condition check
@@ -80,20 +81,19 @@ describe('executeRetry', () => {
     ).rejects.toThrow('Retry execution did not produce an attempt result.')
   })
 
-  it.each([0, -1, 1.5])(
-    'throws an error when maxAttempts is invalid (%s)',
-    async (invalidMaxAttempts) => {
-      await expect(
-        executeRetry(createRequest({ maxAttempts: invalidMaxAttempts }), {
-          runCommand: vi.fn(),
-          delay: vi.fn(),
-          terminateProcessTree: vi.fn(),
-        }),
-      ).rejects.toThrow(
-        `ExecuteRetryRequest.maxAttempts must be a positive integer, but received: ${invalidMaxAttempts}`,
-      )
-    },
-  )
+  it.each([
+    0, -1, 1.5,
+  ])('throws an error when maxAttempts is invalid (%s)', async (invalidMaxAttempts) => {
+    await expect(
+      executeRetry(createRequest({ maxAttempts: invalidMaxAttempts }), {
+        runCommand: vi.fn(),
+        delay: vi.fn(),
+        terminateProcessTree: vi.fn(),
+      }),
+    ).rejects.toThrow(
+      `ExecuteRetryRequest.maxAttempts must be a positive integer, but received: ${invalidMaxAttempts}`,
+    )
+  })
 
   it('returns timeout and terminates process tree when timeout wins', async () => {
     let resolveCompletion!: (value: {


### PR DESCRIPTION
Add explicit unit tests to cover crucial boundary, validation, and error-handling conditions in the execution engine to safeguard against regression risks and ensure the system behaves safely instead of silently failing or causing obscure state problems.

Fixes issue based on plan cover_critical_error_handling_paths.md.

---
*PR created automatically by Jules for task [6476906392054444125](https://jules.google.com/task/6476906392054444125) started by @akitorahayashi*