### PR TITLE
refactor: ensure test determinism and strict isolation in I/O boundaries

### DIFF
--- a/docs/architecture/boundary.md
+++ b/docs/architecture/boundary.md
@@ -43,3 +43,10 @@ The action fails explicitly when:
 - attempts are exhausted and `continue_on_error` is not enabled
 
 No silent fallback paths are used.
+
+## Testing Constraints
+
+Test suites adhere to strict determinism and isolation:
+
+- Pure components (`src/domain/`) are tested exclusively through their public API, verifying output mapping without mock orchestration or timeline manipulation.
+- I/O boundaries and timing mechanisms (`src/adapters/` and `src/app/`) must replace arbitrary execution speed dependencies (`sleep`, `setTimeout`) and event loop mechanics (`process.nextTick`) with deterministic scheduling. Use fake timers or explicit promise resolution tracking to guarantee predictable, sequence-independent evaluation.

--- a/tests/adapters/terminate-process-tree.test.ts
+++ b/tests/adapters/terminate-process-tree.test.ts
@@ -59,16 +59,14 @@ describe('terminateProcessTree', () => {
 
       const child = spawn('bash', [fixture], {
         detached: true,
-        stdio: 'ignore',
+        stdio: ['ignore', 'pipe', 'ignore'],
       })
 
       expect(typeof child.pid).toBe('number')
 
       const pid = child.pid as number
 
-      // Wait a moment for process to actually start before terminating
-      // We read stdout/stderr to ensure it actually started or just wait a bit in real time
-      await new Promise((resolve) => setTimeout(resolve, 50)) // real time wait for process spawn
+      await waitForReadySignal(child)
 
       const closePromise = new Promise<void>((resolve) => {
         child.on('close', () => resolve())
@@ -199,4 +197,53 @@ function isAlive(pid: number): boolean {
   } catch {
     return false
   }
+}
+
+function waitForReadySignal(
+  child: ReturnType<typeof spawn>,
+  signal = 'READY',
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const stdout = child.stdout
+    if (!stdout) {
+      reject(new Error('Child process stdout is not available'))
+      return
+    }
+
+    const onData = (chunk: Buffer | string) => {
+      const output = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      if (!output.includes(signal)) {
+        return
+      }
+      cleanup()
+      resolve()
+    }
+
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+
+    const onClose = (
+      code: number | null,
+      closedSignal: NodeJS.Signals | null,
+    ) => {
+      cleanup()
+      reject(
+        new Error(
+          `Child process exited before readiness signal (code=${String(code)}, signal=${String(closedSignal)})`,
+        ),
+      )
+    }
+
+    const cleanup = () => {
+      stdout.off('data', onData)
+      child.off('error', onError)
+      child.off('close', onClose)
+    }
+
+    stdout.on('data', onData)
+    child.on('error', onError)
+    child.on('close', onClose)
+  })
 }

--- a/tests/adapters/terminate-process-tree.test.ts
+++ b/tests/adapters/terminate-process-tree.test.ts
@@ -5,11 +5,12 @@ import { terminateProcessTree } from '../../src/adapters/terminate-process-tree'
 
 describe('terminateProcessTree', () => {
   // Grace period constants for test clarity
-  const GRACE_PERIOD_SECONDS = 0.05
+  const GRACE_PERIOD_SECONDS = 5
   const GRACE_PERIOD_MS = GRACE_PERIOD_SECONDS * 1000
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.useRealTimers()
   })
 
   it('terminates long-running process by pid', async () => {
@@ -32,7 +33,9 @@ describe('terminateProcessTree', () => {
     })
 
     try {
+      vi.useFakeTimers()
       const terminatePromise = terminateProcessTree(pid, GRACE_PERIOD_SECONDS)
+      await vi.advanceTimersByTimeAsync(GRACE_PERIOD_MS)
 
       await terminatePromise
       await closePromise
@@ -64,14 +67,17 @@ describe('terminateProcessTree', () => {
       const pid = child.pid as number
 
       // Wait a moment for process to actually start before terminating
-      await new Promise((resolve) => setTimeout(resolve, GRACE_PERIOD_MS))
+      // We read stdout/stderr to ensure it actually started or just wait a bit in real time
+      await new Promise((resolve) => setTimeout(resolve, 50)) // real time wait for process spawn
 
       const closePromise = new Promise<void>((resolve) => {
         child.on('close', () => resolve())
       })
 
       try {
+        vi.useFakeTimers()
         const terminatePromise = terminateProcessTree(pid, GRACE_PERIOD_SECONDS)
+        await vi.advanceTimersByTimeAsync(GRACE_PERIOD_MS)
 
         await terminatePromise
         await closePromise
@@ -118,7 +124,9 @@ describe('terminateProcessTree', () => {
       })
 
       try {
+        vi.useFakeTimers()
         const terminatePromise = terminateProcessTree(pid, GRACE_PERIOD_SECONDS)
+        await vi.advanceTimersByTimeAsync(GRACE_PERIOD_MS)
 
         await terminatePromise
         await closePromise
@@ -165,7 +173,9 @@ describe('terminateProcessTree', () => {
         })
 
       try {
+        vi.useFakeTimers()
         const terminatePromise = terminateProcessTree(pid, GRACE_PERIOD_SECONDS)
+        await vi.advanceTimersByTimeAsync(GRACE_PERIOD_MS)
 
         await terminatePromise
 

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -218,7 +218,10 @@ describe('awaitAttemptOutcome', () => {
       terminationGraceSeconds: 5,
     }
 
-    let resolveCompletion!: (value: any) => void
+    let resolveCompletion!: (value: {
+      exitCode: number
+      stdout: string
+    }) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
       (resolve) => {
         resolveCompletion = resolve
@@ -273,7 +276,10 @@ describe('awaitAttemptOutcome', () => {
       terminationGraceSeconds: 5,
     }
 
-    let resolveCompletion!: (value: any) => void
+    let resolveCompletion!: (value: {
+      exitCode: number
+      stdout: string
+    }) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
       (resolve) => {
         resolveCompletion = resolve
@@ -327,7 +333,10 @@ describe('awaitAttemptOutcome', () => {
       terminationGraceSeconds: 5,
     }
 
-    let resolveCompletion!: (value: any) => void
+    let resolveCompletion!: (value: {
+      exitCode: number
+      stdout: string
+    }) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
       (resolve) => {
         resolveCompletion = resolve

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -83,20 +83,31 @@ describe('awaitAttemptOutcome', () => {
       completion: Promise.resolve({ exitCode: 0, stdout: '{"ok":true}' }),
     }
     const cancelTimeout = vi.fn()
+
+    // Create a resolvable promise to represent a delay that never triggered before completion
+    let resolveDelay!: () => void
+    const delayPromise = new Promise<void>((resolve) => { resolveDelay = resolve })
+
     const dependencies = {
       delay: vi.fn().mockReturnValue({
-        promise: new Promise(() => {}), // Never resolves so completion wins
+        promise: delayPromise,
         cancel: cancelTimeout,
       }),
       terminateProcessTree: vi.fn(),
     }
 
-    const result = await awaitAttemptOutcome(
+    const resultPromise = awaitAttemptOutcome(
       command,
       1,
       runningCommand,
       dependencies,
     )
+
+    // Resolve delay to ensure test cleans up even though completion is faster
+    resolveDelay()
+
+    const result = await resultPromise
+
     expect(result).toEqual({
       outcome: 'success',
       exitCode: 0,
@@ -136,6 +147,12 @@ describe('awaitAttemptOutcome', () => {
     const cancelInitialTimeout = vi.fn()
     const cancelTerminationTimeout = vi.fn()
 
+    let resolveTerminationDelay!: () => void
+    const terminationDelayPromise = new Promise<void>((resolve) => { resolveTerminationDelay = resolve })
+
+    let resolveTerminateProcessTree!: () => void
+    const terminateProcessTreePromise = new Promise<void>((resolve) => { resolveTerminateProcessTree = resolve })
+
     const dependencies = {
       delay: vi
         .fn()
@@ -146,10 +163,13 @@ describe('awaitAttemptOutcome', () => {
         })
         .mockReturnValueOnce({
           // Second delay is the 5000ms termination timeout
-          promise: new Promise(() => {}), // Never resolves so completion wins
+          promise: terminationDelayPromise,
           cancel: cancelTerminationTimeout,
         }),
-      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+      terminateProcessTree: vi.fn().mockImplementation(() => {
+        resolveTerminateProcessTree()
+        return Promise.resolve()
+      }),
     }
 
     const attemptPromise = awaitAttemptOutcome(
@@ -162,10 +182,13 @@ describe('awaitAttemptOutcome', () => {
     // Trigger initial timeout
     resolveInitialTimeout()
 
-    // Allow event loop to process
-    await new Promise(process.nextTick)
+    // Await deterministic execution of termination instead of arbitrary tick
+    await terminateProcessTreePromise
 
     expect(dependencies.terminateProcessTree).toHaveBeenCalledWith(1234, 5)
+
+    // Resolve the termination delay to ensure clean up
+    resolveTerminationDelay()
 
     // Resolve the process completion
     resolveCompletion({ exitCode: 143, stdout: 'partial\n' }) // Simulate exit due to SIGTERM
@@ -189,8 +212,9 @@ describe('awaitAttemptOutcome', () => {
       terminationGraceSeconds: 5,
     }
 
+    let resolveCompletion!: (value: any) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      () => {},
+      (resolve) => { resolveCompletion = resolve },
     )
 
     const runningCommand: RunningCommand = {
@@ -200,6 +224,9 @@ describe('awaitAttemptOutcome', () => {
     }
 
     const cancelTimeout = vi.fn()
+    let resolveTerminationDelay!: () => void
+    const terminationDelayPromise = new Promise<void>((resolve) => { resolveTerminationDelay = resolve })
+
     const dependencies = {
       delay: vi
         .fn()
@@ -208,7 +235,7 @@ describe('awaitAttemptOutcome', () => {
           cancel: cancelTimeout,
         })
         .mockReturnValueOnce({
-          promise: new Promise(() => {}), // Second delay never resolves
+          promise: terminationDelayPromise, // Second delay
           cancel: vi.fn(),
         }),
       terminateProcessTree: vi.fn().mockRejectedValue(new Error('Kill failed')),
@@ -221,11 +248,11 @@ describe('awaitAttemptOutcome', () => {
       dependencies,
     )
 
-    await new Promise(process.nextTick)
-
+    await expect(attemptPromise).rejects.toThrow('Kill failed')
     expect(dependencies.terminateProcessTree).toHaveBeenCalled()
 
-    await expect(attemptPromise).rejects.toThrow('Kill failed')
+    resolveCompletion({ exitCode: 1, stdout: '' })
+    resolveTerminationDelay()
   })
 
   it('throws when terminateProcessTree fails with a non-Error value', async () => {
@@ -236,8 +263,9 @@ describe('awaitAttemptOutcome', () => {
       terminationGraceSeconds: 5,
     }
 
+    let resolveCompletion!: (value: any) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      () => {},
+      (resolve) => { resolveCompletion = resolve },
     )
 
     const runningCommand: RunningCommand = {
@@ -245,6 +273,9 @@ describe('awaitAttemptOutcome', () => {
       isRunning: () => true,
       completion: completionPromise,
     }
+
+    let resolveTerminationDelay!: () => void
+    const terminationDelayPromise = new Promise<void>((resolve) => { resolveTerminationDelay = resolve })
 
     const dependencies = {
       delay: vi
@@ -254,7 +285,7 @@ describe('awaitAttemptOutcome', () => {
           cancel: vi.fn(),
         })
         .mockReturnValueOnce({
-          promise: new Promise(() => {}), // Second delay never resolves
+          promise: terminationDelayPromise,
           cancel: vi.fn(),
         }),
       terminateProcessTree: vi.fn().mockRejectedValue('String error message'),
@@ -266,9 +297,12 @@ describe('awaitAttemptOutcome', () => {
       runningCommand,
       dependencies,
     )
-    await new Promise(process.nextTick)
 
     await expect(attemptPromise).rejects.toBe('String error message')
+    expect(dependencies.terminateProcessTree).toHaveBeenCalled()
+
+    resolveCompletion({ exitCode: 1, stdout: '' })
+    resolveTerminationDelay()
   })
 
   it('returns a safe outcome without exit code if termination fallback timeout triggers', async () => {
@@ -279,10 +313,15 @@ describe('awaitAttemptOutcome', () => {
       terminationGraceSeconds: 5,
     }
 
+    let resolveCompletion!: (value: any) => void
+    const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
+      (resolve) => { resolveCompletion = resolve },
+    )
+
     const runningCommand: RunningCommand = {
       pid: 1234,
       isRunning: () => true,
-      completion: new Promise(() => {}), // Never completes
+      completion: completionPromise,
     }
 
     const dependencies = {
@@ -299,14 +338,17 @@ describe('awaitAttemptOutcome', () => {
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
     }
 
-    const result = await awaitAttemptOutcome(
+    const resultPromise = awaitAttemptOutcome(
       command,
       1,
       runningCommand,
       dependencies,
     )
 
+    const result = await resultPromise
+
     expect(result).toEqual({ outcome: 'timeout', exitCode: null, stdout: '' })
+    resolveCompletion({ exitCode: 1, stdout: '' })
   })
 })
 

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -86,7 +86,9 @@ describe('awaitAttemptOutcome', () => {
 
     // Create a resolvable promise to represent a delay that never triggered before completion
     let resolveDelay!: () => void
-    const delayPromise = new Promise<void>((resolve) => { resolveDelay = resolve })
+    const delayPromise = new Promise<void>((resolve) => {
+      resolveDelay = resolve
+    })
 
     const dependencies = {
       delay: vi.fn().mockReturnValue({
@@ -148,10 +150,14 @@ describe('awaitAttemptOutcome', () => {
     const cancelTerminationTimeout = vi.fn()
 
     let resolveTerminationDelay!: () => void
-    const terminationDelayPromise = new Promise<void>((resolve) => { resolveTerminationDelay = resolve })
+    const terminationDelayPromise = new Promise<void>((resolve) => {
+      resolveTerminationDelay = resolve
+    })
 
     let resolveTerminateProcessTree!: () => void
-    const terminateProcessTreePromise = new Promise<void>((resolve) => { resolveTerminateProcessTree = resolve })
+    const terminateProcessTreePromise = new Promise<void>((resolve) => {
+      resolveTerminateProcessTree = resolve
+    })
 
     const dependencies = {
       delay: vi
@@ -214,7 +220,9 @@ describe('awaitAttemptOutcome', () => {
 
     let resolveCompletion!: (value: any) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => { resolveCompletion = resolve },
+      (resolve) => {
+        resolveCompletion = resolve
+      },
     )
 
     const runningCommand: RunningCommand = {
@@ -225,7 +233,9 @@ describe('awaitAttemptOutcome', () => {
 
     const cancelTimeout = vi.fn()
     let resolveTerminationDelay!: () => void
-    const terminationDelayPromise = new Promise<void>((resolve) => { resolveTerminationDelay = resolve })
+    const terminationDelayPromise = new Promise<void>((resolve) => {
+      resolveTerminationDelay = resolve
+    })
 
     const dependencies = {
       delay: vi
@@ -265,7 +275,9 @@ describe('awaitAttemptOutcome', () => {
 
     let resolveCompletion!: (value: any) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => { resolveCompletion = resolve },
+      (resolve) => {
+        resolveCompletion = resolve
+      },
     )
 
     const runningCommand: RunningCommand = {
@@ -275,7 +287,9 @@ describe('awaitAttemptOutcome', () => {
     }
 
     let resolveTerminationDelay!: () => void
-    const terminationDelayPromise = new Promise<void>((resolve) => { resolveTerminationDelay = resolve })
+    const terminationDelayPromise = new Promise<void>((resolve) => {
+      resolveTerminationDelay = resolve
+    })
 
     const dependencies = {
       delay: vi
@@ -315,7 +329,9 @@ describe('awaitAttemptOutcome', () => {
 
     let resolveCompletion!: (value: any) => void
     const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => { resolveCompletion = resolve },
+      (resolve) => {
+        resolveCompletion = resolve
+      },
     )
 
     const runningCommand: RunningCommand = {

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -134,7 +134,16 @@ describe('executeRetry', () => {
       resolveCompletion = resolve
     })
 
-    const terminateProcessTree = vi.fn().mockResolvedValue(undefined)
+    let resolveTerminate!: () => void
+    const terminatePromise = new Promise<void>((resolve) => {
+      resolveTerminate = resolve
+    })
+
+    const terminateProcessTree = vi.fn().mockImplementation(() => {
+      resolveTerminate()
+      return Promise.resolve()
+    })
+
     const runCommand = vi.fn().mockReturnValue({
       pid,
       completion: completionPromise,
@@ -155,9 +164,8 @@ describe('executeRetry', () => {
 
     signalHandler()
 
-    await vi.waitFor(() => {
-      expect(terminateProcessTree).toHaveBeenCalledWith(pid, 1)
-    })
+    await terminatePromise
+    expect(terminateProcessTree).toHaveBeenCalledWith(pid, 1)
 
     resolveCompletion({ exitCode: null, stdout: '' })
     await resultPromise

--- a/tests/app/terminate-command-on-signal.test.ts
+++ b/tests/app/terminate-command-on-signal.test.ts
@@ -3,14 +3,21 @@ import { registerCommandTerminationOnSignal } from '../../src/app/execute-retry/
 import type { RunningCommand } from '../../src/adapters/run-shell-command'
 
 function createProcessSpies() {
+  let resolveExit!: (code: number) => void
+  const exitDone = new Promise<number>((resolve) => {
+    resolveExit = resolve
+  })
+
   return {
     once: vi.spyOn(process, 'once').mockReturnThis(),
     off: vi.spyOn(process, 'off').mockReturnThis(),
     exit: vi
       .spyOn(process, 'exit')
-      .mockImplementation((_code?: number | string | null) => {
+      .mockImplementation((code?: number | string | null) => {
+        resolveExit(Number(code))
         return undefined as never
       }),
+    exitDone,
   }
 }
 
@@ -80,7 +87,7 @@ describe('registerCommandTerminationOnSignal', () => {
     expect(sigtermHandler).toBeDefined()
 
     sigtermHandler?.()
-    await new Promise(process.nextTick) // Allow promise chain to resolve
+    await processSpies.exitDone
 
     expect(params.terminateProcessTree).not.toHaveBeenCalled()
     expect(processSpies.exit).toHaveBeenCalledWith(0)
@@ -108,13 +115,13 @@ describe('registerCommandTerminationOnSignal', () => {
     )
 
     sigtermHandler?.()
-    await new Promise(process.nextTick) // Allow promise and catch blocks to resolve
+    await processSpies.exitDone
 
     expect(params.terminateProcessTree).toHaveBeenCalledWith(1234, 5)
     expect(processSpies.exit).toHaveBeenCalledWith(0) // Inner catch block handles it
   })
 
-  it('catches non-Error outer errors in handler and exits with 1', async () => {
+  it('catches non-Error outer errors in handler and exits with 1 on SIGTERM', async () => {
     const processSpies = createProcessSpies()
     const params = {
       getRunningCommand: vi.fn().mockImplementation(() => {
@@ -132,20 +139,30 @@ describe('registerCommandTerminationOnSignal', () => {
     )
 
     sigtermHandler?.()
-    await new Promise(process.nextTick) // Allow outer catch block to resolve
+    await processSpies.exitDone
 
     // The handler's catch block should have called process.exit(1)
     expect(processSpies.exit).toHaveBeenCalledWith(1)
+  })
 
-    // Also test SIGINT throwing a non-Error outer error
-    processSpies.exit.mockClear()
+  it('catches non-Error outer errors in handler and exits with 1 on SIGINT', async () => {
+    const processSpies = createProcessSpies()
+    const params = {
+      getRunningCommand: vi.fn().mockImplementation(() => {
+        throw 'String outer error'
+      }),
+      terminationGraceSeconds: 5,
+      terminateProcessTree: vi.fn(),
+    }
+
+    registerCommandTerminationOnSignal(params)
 
     const sigintHandler = findSignalHandler(
       processSpies.once.mock.calls,
       'SIGINT',
     )
     sigintHandler?.()
-    await new Promise(process.nextTick)
+    await processSpies.exitDone
 
     expect(processSpies.exit).toHaveBeenCalledWith(1)
   })
@@ -172,7 +189,7 @@ describe('registerCommandTerminationOnSignal', () => {
     )
 
     sigtermHandler?.()
-    await new Promise(process.nextTick)
+    await processSpies.exitDone
 
     expect(params.terminateProcessTree).toHaveBeenCalledWith(1234, 5)
     expect(processSpies.exit).toHaveBeenCalledWith(0)
@@ -200,7 +217,7 @@ describe('registerCommandTerminationOnSignal', () => {
     )
 
     sigintHandler?.()
-    await new Promise(process.nextTick)
+    await processSpies.exitDone
 
     expect(params.terminateProcessTree).toHaveBeenCalledWith(1234, 5)
     expect(processSpies.exit).toHaveBeenCalledWith(0)
@@ -228,13 +245,13 @@ describe('registerCommandTerminationOnSignal', () => {
     )
 
     sigtermHandler?.()
-    await new Promise(process.nextTick) // Allow promise and catch blocks to resolve
+    await processSpies.exitDone
 
     expect(params.terminateProcessTree).toHaveBeenCalledWith(1234, 5)
     expect(processSpies.exit).toHaveBeenCalledWith(0) // Inner catch block handles it
   })
 
-  it('catches outer errors in handler and exits with 1', async () => {
+  it('catches outer errors in handler and exits with 1 on SIGTERM', async () => {
     const processSpies = createProcessSpies()
     const params = {
       getRunningCommand: vi.fn().mockImplementation(() => {
@@ -252,19 +269,30 @@ describe('registerCommandTerminationOnSignal', () => {
     )
 
     sigtermHandler?.()
-    await new Promise(process.nextTick) // Allow outer catch block to resolve
+    await processSpies.exitDone
 
     // The handler's catch block should have called process.exit(1)
     expect(processSpies.exit).toHaveBeenCalledWith(1)
+  })
 
-    processSpies.exit.mockClear()
+  it('catches outer errors in handler and exits with 1 on SIGINT', async () => {
+    const processSpies = createProcessSpies()
+    const params = {
+      getRunningCommand: vi.fn().mockImplementation(() => {
+        throw new Error('Unexpected error in handler setup')
+      }),
+      terminationGraceSeconds: 5,
+      terminateProcessTree: vi.fn(),
+    }
+
+    registerCommandTerminationOnSignal(params)
 
     const sigintHandler = findSignalHandler(
       processSpies.once.mock.calls,
       'SIGINT',
     )
     sigintHandler?.()
-    await new Promise(process.nextTick)
+    await processSpies.exitDone
 
     expect(processSpies.exit).toHaveBeenCalledWith(1)
   })

--- a/tests/fixtures/commands/ignore-term-then-exit.sh
+++ b/tests/fixtures/commands/ignore-term-then-exit.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 trap '' TERM
 
+echo 'READY'
+
 while true; do
   sleep 1
 done


### PR DESCRIPTION
This PR updates the test suite to decouple test execution from arbitrary real-world process speed (`setTimeout`, `sleep`) and JavaScript event-loop ticks (`process.nextTick`). Tests now rely on deterministic fake timers and explicitly resolvable promises to ensure precise synchronization and testing of boundary components. It updates corresponding guidelines in `docs/architecture/boundary.md`.

---
*PR created automatically by Jules for task [17108118099083719329](https://jules.google.com/task/17108118099083719329) started by @akitorahayashi*