### PR TITLE
Fix: Unify error handling semantics

### DIFF
--- a/src/adapters/run-shell-command.ts
+++ b/src/adapters/run-shell-command.ts
@@ -32,16 +32,18 @@ export function runShellCommand(
     stdout += chunk.toString()
     try {
       process.stdout.write(chunk)
-    } catch {
-      // Ignore stdout forwarding failures so command completion can still resolve.
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      console.warn(`[runShellCommand] Failed to write to stdout: ${msg}`)
     }
   })
 
   child.stderr?.on('data', (chunk) => {
     try {
       process.stderr.write(chunk)
-    } catch {
-      // Ignore stderr forwarding failures so command completion can still resolve.
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error)
+      console.warn(`[runShellCommand] Failed to write to stderr: ${msg}`)
     }
   })
 

--- a/src/adapters/terminate-process-tree.ts
+++ b/src/adapters/terminate-process-tree.ts
@@ -15,14 +15,29 @@ function sendSignal(pid: number, signal: NodeJS.Signals): void {
   try {
     process.kill(-pid, signal)
     return
-  } catch {
+  } catch (error) {
     // Fallback to direct pid signaling when process groups are not available.
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+      // Expected when process group doesn't exist
+    } else {
+      console.warn(
+        `[sendSignal] Process group signal failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
   }
 
   try {
     process.kill(pid, signal)
-  } catch {
-    // The process may already be gone.
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+      // The process is already gone
+      return
+    }
+    // Handle mock errors or non-NodeJS errors that start with 'ESRCH' string in message
+    if (error instanceof Error && error.message.startsWith('ESRCH')) {
+      return
+    }
+    throw error
   }
 }
 
@@ -30,8 +45,21 @@ function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0)
     return true
-  } catch {
-    return false
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+      return false
+    }
+    if (error instanceof Error && 'code' in error && error.code === 'EPERM') {
+      return true
+    }
+    // Handle mock errors or non-NodeJS errors that start with 'ESRCH' or 'EPERM' string in message
+    if (error instanceof Error && error.message.startsWith('ESRCH')) {
+      return false
+    }
+    if (error instanceof Error && error.message.startsWith('EPERM')) {
+      return true
+    }
+    throw error
   }
 }
 

--- a/src/adapters/terminate-process-tree.ts
+++ b/src/adapters/terminate-process-tree.ts
@@ -17,7 +17,7 @@ function sendSignal(pid: number, signal: NodeJS.Signals): void {
     return
   } catch (error) {
     // Fallback to direct pid signaling when process groups are not available.
-    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+    if (matchesCode(error, 'ESRCH')) {
       // Expected when process group doesn't exist
     } else {
       console.warn(
@@ -29,12 +29,8 @@ function sendSignal(pid: number, signal: NodeJS.Signals): void {
   try {
     process.kill(pid, signal)
   } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+    if (matchesCode(error, 'ESRCH')) {
       // The process is already gone
-      return
-    }
-    // Handle mock errors or non-NodeJS errors that start with 'ESRCH' string in message
-    if (error instanceof Error && error.message.startsWith('ESRCH')) {
       return
     }
     throw error
@@ -46,17 +42,10 @@ function isAlive(pid: number): boolean {
     process.kill(pid, 0)
     return true
   } catch (error) {
-    if (error instanceof Error && 'code' in error && error.code === 'ESRCH') {
+    if (matchesCode(error, 'ESRCH')) {
       return false
     }
-    if (error instanceof Error && 'code' in error && error.code === 'EPERM') {
-      return true
-    }
-    // Handle mock errors or non-NodeJS errors that start with 'ESRCH' or 'EPERM' string in message
-    if (error instanceof Error && error.message.startsWith('ESRCH')) {
-      return false
-    }
-    if (error instanceof Error && error.message.startsWith('EPERM')) {
+    if (matchesCode(error, 'EPERM')) {
       return true
     }
     throw error
@@ -67,4 +56,11 @@ function wait(milliseconds: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, milliseconds)
   })
+}
+
+function matchesCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    (('code' in error && error.code === code) || error.message.startsWith(code))
+  )
 }

--- a/src/app/execute-retry/execute-attempt.ts
+++ b/src/app/execute-retry/execute-attempt.ts
@@ -28,44 +28,59 @@ export async function executeAttempt(
   })
 
   try {
-    runningCommand = dependencies.runCommand(command.command, command.shell)
+    try {
+      runningCommand = dependencies.runCommand(command.command, command.shell)
 
-    const result = await awaitAttemptOutcome(
-      command,
-      attempt,
-      runningCommand,
-      dependencies,
-    )
+      const result = await awaitAttemptOutcome(
+        command,
+        attempt,
+        runningCommand,
+        dependencies,
+      )
 
-    logAttemptCompletion(attempt, result.outcome, result.exitCode)
+      logAttemptCompletion(attempt, result.outcome, result.exitCode)
 
-    if (result.outcome === 'success') {
-      if (result.exitCode === null) {
-        throw new Error('Successful attempt must include a numeric exit code.')
+      if (result.outcome === 'success') {
+        if (result.exitCode === null) {
+          throw new Error(
+            'Successful attempt must include a numeric exit code.',
+          )
+        }
+
+        return {
+          attempt,
+          outcome: 'success',
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+        }
+      }
+
+      if (result.outcome === 'timeout') {
+        return {
+          attempt,
+          outcome: 'timeout',
+          exitCode: null,
+          stdout: result.stdout,
+        }
       }
 
       return {
         attempt,
-        outcome: 'success',
+        outcome: 'error',
         exitCode: result.exitCode,
         stdout: result.stdout,
       }
-    }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error)
+      core.error(`Attempt ${attempt} failed with error: ${errorMessage}`)
 
-    if (result.outcome === 'timeout') {
       return {
         attempt,
-        outcome: 'timeout',
+        outcome: 'error',
         exitCode: null,
-        stdout: result.stdout,
+        stdout: '',
       }
-    }
-
-    return {
-      attempt,
-      outcome: 'error',
-      exitCode: result.exitCode,
-      stdout: result.stdout,
     }
   } finally {
     cleanupSignalHandlers()

--- a/tests/adapters/terminate-process-tree.test.ts
+++ b/tests/adapters/terminate-process-tree.test.ts
@@ -180,6 +180,22 @@ describe('terminateProcessTree', () => {
       }
     })
   })
+
+  describe('unexpected errors', () => {
+    it('throws unexpected errors during sendSignal', async () => {
+      const killSpy = vi
+        .spyOn(process, 'kill')
+        .mockImplementation((_targetPid, _signal) => {
+          throw new Error('EACCES: permission denied')
+        })
+
+      await expect(
+        terminateProcessTree(100, GRACE_PERIOD_SECONDS),
+      ).rejects.toThrow('EACCES: permission denied')
+
+      expect(killSpy).toHaveBeenCalled()
+    })
+  })
 })
 
 function isAlive(pid: number): boolean {

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -276,37 +276,49 @@ describe('executeRetry', () => {
     expect(result.attempts).toBe(3)
   })
 
-  it('escalates synchronous errors from runCommand', async () => {
-    const runCommand = vi.fn().mockImplementationOnce(() => {
+  it('captures synchronous errors from runCommand as attempt errors', async () => {
+    const runCommand = vi.fn().mockImplementation(() => {
       throw new Error('spawn failed')
     })
 
-    await expect(
-      executeRetry(createRequest({ maxAttempts: 2 }), {
-        runCommand,
-        delay: vi.fn().mockReturnValue(createNeverDelay()),
-        terminateProcessTree: vi.fn().mockResolvedValue(undefined),
-      }),
-    ).rejects.toThrow('spawn failed')
+    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
+      runCommand,
+      delay: vi.fn().mockReturnValue(createNeverDelay()),
+      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+    })
 
-    expect(runCommand).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      attempts: 2,
+      finalExitCode: null,
+      finalOutcome: 'error',
+      succeeded: false,
+      finalStdout: '',
+    })
+
+    expect(runCommand).toHaveBeenCalledTimes(2)
   })
 
-  it('escalates promise rejections from runCommand completion', async () => {
-    const runCommand = vi.fn().mockReturnValueOnce({
+  it('captures promise rejections from runCommand completion as attempt errors', async () => {
+    const runCommand = vi.fn().mockReturnValue({
       pid: 101,
       completion: Promise.reject(new Error('process crashed')),
       isRunning: () => false,
     })
 
-    await expect(
-      executeRetry(createRequest({ maxAttempts: 2 }), {
-        runCommand,
-        delay: vi.fn().mockReturnValue(createNeverDelay()),
-        terminateProcessTree: vi.fn().mockResolvedValue(undefined),
-      }),
-    ).rejects.toThrow('process crashed')
+    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
+      runCommand,
+      delay: vi.fn().mockReturnValue(createNeverDelay()),
+      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+    })
 
-    expect(runCommand).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      attempts: 2,
+      finalExitCode: null,
+      finalOutcome: 'error',
+      succeeded: false,
+      finalStdout: '',
+    })
+
+    expect(runCommand).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
Fixes issues around execution domain fallbacks where stdout/stderr could fail quietly and unexpected errors bypassed retry loops entirely. Ensure explicit error handling on missing signals (`ESRCH`), and capture execution resolutions as valid `outcome: 'error'` structs.

---
*PR created automatically by Jules for task [9304407021743742913](https://jules.google.com/task/9304407021743742913) started by @akitorahayashi*