### PR TITLE
docs: emit taxonomy events

### DIFF
--- a/.jules/exchange/events/attempt_result_taxonomy.md
+++ b/.jules/exchange/events/attempt_result_taxonomy.md
@@ -1,0 +1,45 @@
+---
+label: "refacts"
+created_at: "2024-05-25"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The concept of an execution's result or outcome is represented by multiple overlapping terms: `AttemptOutcome` (domain), `AttemptResult` (domain), and `ExecutionResult` (app).
+
+- `AttemptOutcome` is a union of string literals: `'success' | 'error' | 'timeout'`.
+- `AttemptResult` includes `attempt`, `outcome`, `exitCode`, and `stdout`.
+- `ExecutionResult` includes `outcome`, `exitCode`, and `stdout`, missing the `attempt` number.
+
+`ExecutionResult` is essentially a partial `AttemptResult` returned by `awaitAttemptOutcome`. The naming makes the boundary between the command's raw completion and the domain's tracked attempt confusing.
+
+## Goal
+
+Unify or clearly delineate the vocabulary for the outcome of a command execution vs. the result of a retry attempt.
+
+## Context
+
+Having `AttemptOutcome` (a string), `AttemptResult` (an object including the attempt number), and `ExecutionResult` (an object without the attempt number) makes it hard to discuss "the result of running the command." The domain currently owns `AttemptOutcome` and `AttemptResult`. The application layer introduces `ExecutionResult` purely because `awaitAttemptOutcome` doesn't know (or doesn't include) the attempt number until the caller (`executeAttempt`) merges it in.
+
+## Evidence
+
+- path: "src/domain/policy.ts"
+  loc: "line 1"
+  note: "Defines `AttemptOutcome` as a string literal union."
+
+- path: "src/domain/result.ts"
+  loc: "line 1"
+  note: "Defines `AttemptResult` as an object containing `outcome` (an `AttemptOutcome`)."
+
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "line 15"
+  note: "Defines `ExecutionResult` which is nearly identical to `AttemptResult` but lacks the `attempt` field."
+
+## Change Scope
+
+- `src/domain/policy.ts`
+- `src/domain/result.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `src/app/execute-retry/execute-attempt.ts`

--- a/.jules/exchange/events/delay_terminology_taxonomy.md
+++ b/.jules/exchange/events/delay_terminology_taxonomy.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2024-05-25"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Configuration keys, internal domain terminology, and output logs lack a consistent naming convention for "delay" concepts.
+
+The action input accepts `retry_delay_seconds` and `retry_delay_schedule_seconds` but internally this concept is represented in multiple ways, such as `retryDelaySeconds`, `delaySeconds`, and the `delay` adapter.
+
+## Goal
+
+Ensure that "delay" consistently conveys whether it is the user-configured retry delay, the calculated delay for the current attempt, or the primitive wait operation.
+
+## Context
+
+The concept of a delay appears at the CLI/Config boundary (as `retry_delay_seconds`), in the Domain (as `RetrySchedule.retryDelaySeconds`), in the App layer (`delaySeconds`), and in the Infrastructure (`delay` function). It is crucial that the transition from a configured "retry delay schedule" to a specific "delay" for a given attempt is clear.
+
+## Evidence
+
+- path: "src/domain/schedule.ts"
+  loc: "lines 1-4"
+  note: "Defines `RetrySchedule` with `retryDelaySeconds` and `retryDelayScheduleSeconds`."
+
+- path: "src/app/execute-retry/index.ts"
+  loc: "line 55"
+  note: "The application layer resolves this schedule to a `delaySeconds` local variable."
+
+- path: "src/adapters/delay.ts"
+  loc: "line 1"
+  note: "The infrastructure provides a `delay` primitive."
+
+## Change Scope
+
+- `src/domain/schedule.ts`
+- `src/app/execute-retry/index.ts`

--- a/.jules/exchange/events/exit_code_format_taxonomy.md
+++ b/.jules/exchange/events/exit_code_format_taxonomy.md
@@ -1,0 +1,42 @@
+---
+label: "refacts"
+created_at: "2024-05-25"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The internal code uses `exitCode` (number | null) for the command execution outcome, and `formatExitCode` to produce a display string (like `'none'`), but the action output is named `final_exit_code`, which emits an empty string `''` when no code is available instead of `'none'`.
+
+## Goal
+
+Align the handling and string representation of a missing exit code across the domain, logging, and outputs.
+
+## Context
+
+When a command times out or is terminated, it does not have a numeric exit code. The domain represents this as `exitCode: null`.
+
+The app layer logging explicitly translates `null` to the literal string `'none'` via `formatExitCode`.
+
+The `emitOutputs` adapter translates `null` to an empty string `''` for the `final_exit_code` action output. The user-facing output shape does not match the internal logged shape for this missing value.
+
+## Evidence
+
+- path: "src/app/execute-retry/format-exit-code.ts"
+  loc: "line 2"
+  note: "Returns `'none'` when `exitCode === null` for application logging."
+
+- path: "src/action/emit-outputs.ts"
+  loc: "line 8"
+  note: "Emits `''` (empty string) when `result.exitCode === null` for the GitHub Actions output."
+
+- path: "docs/configuration/inputs.md"
+  loc: "Outputs table"
+  note: "Documents `final_exit_code` as 'empty when no code is available'."
+
+## Change Scope
+
+- `src/app/execute-retry/format-exit-code.ts`
+- `src/action/emit-outputs.ts`
+- `docs/configuration/inputs.md`


### PR DESCRIPTION
This change creates three taxonomy observer events to highlight inconsistencies in the vocabulary used in the repository:
- `attempt_result_taxonomy.md` points out the overlap between `AttemptOutcome`, `AttemptResult`, and `ExecutionResult`.
- `delay_terminology_taxonomy.md` notes the inconsistency between the configuration (`retry_delay_seconds`), domain (`retryDelaySeconds`), application (`delaySeconds`), and infrastructure (`delay`).
- `exit_code_format_taxonomy.md` points out that the missing exit code is formatted as `'none'` in application logging, but output as an empty string in the GitHub Actions output (`final_exit_code`).

---
*PR created automatically by Jules for task [17335241745374575065](https://jules.google.com/task/17335241745374575065) started by @akitorahayashi*