### PR TITLE
Emit typescripter events

### DIFF
--- a/.jules/exchange/events/discriminated_union_deconstruction_typescripter.md
+++ b/.jules/exchange/events/discriminated_union_deconstruction_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-16"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Deconstruction of discriminated union allows unrepresentable states at the policy boundary. The `shouldRetryFailure` function splits the `AttemptResult` (a discriminated union) into independent `outcome` and `exitCode` primitives, discarding the type safety provided by the union and enabling unrepresentable states to be expressed in parameter inputs.
+
+## Goal
+
+Pass the discriminated union (`AttemptResult` or a similar dedicated union) directly to functions that evaluate state, maintaining exhaustive compiler checks and preventing invalid combinations from being representable.
+
+## Context
+
+A core typescript principle is to model state as discriminated unions so that invalid states are unrepresentable. By destructing the type-safe `AttemptResult` union back into separate primitive variables (like an outcome string and a nullable exitCode number), functions are forced to trust that their callers aren't providing mismatched pairs (e.g. `outcome: 'timeout', exitCode: 1`), and the compiler cannot protect the domain boundary.
+
+## Evidence
+
+- path: "src/domain/policy.ts"
+  loc: "6-10"
+  note: "`shouldRetryFailure` takes `outcome: AttemptOutcome` and `exitCode: number | null` independently instead of maintaining the strict relationship."
+- path: "src/app/execute-retry/index.ts"
+  loc: "38"
+  note: "The type-safe `finalAttempt` union is destructured to call `shouldRetryFailure`, discarding the union's integrity at the function boundary."
+
+## Change Scope
+
+- `src/domain/policy.ts`
+- `src/app/execute-retry/index.ts`

--- a/.jules/exchange/events/mixed_failure_semantics_typescripter.md
+++ b/.jules/exchange/events/mixed_failure_semantics_typescripter.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-16"
+author_role: "typescripter"
+confidence: "high"
+---
+
+## Problem
+
+Mixed failure semantics and swallowed infrastructure errors. The application boundary catches framework and JS-level errors (like `TypeError` or process spawn failures) and coerces them into a domain-level failure (`outcome: 'error'`). This causes unrecoverable infrastructure bugs to be treated as command failures, which incorrectly triggers the retry policy.
+
+## Goal
+
+Consistently separate operational/infrastructure errors (which should throw and fail the action fast) from domain errors (like command execution returning a non-zero exit code or timing out, which should be modeled as Result unions and appropriately retried based on policy).
+
+## Context
+
+Failures are part of the API. When a system mixes infrastructure errors (like `ENOENT` on process spawn or an undefined reference in the JS code) with domain results (the external script exited with a code), it becomes impossible to distinguish between a bug in the action itself versus a failure of the payload. The `catch (error)` in `executeAttempt` currently swallows actual JS errors and forces them into a default `AttemptResult` return value. As a result, the action will attempt to retry an unrecoverable failure, hiding the missing stack trace and preventing fast-failure.
+
+## Evidence
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "53-63"
+  note: "A blanket `catch (error)` captures all exceptions and coerces them into `{ outcome: 'error', exitCode: null }`, meaning runtime JS exceptions are treated as command failures and will be retried."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "35-37"
+  note: "Throws a raw `Error` (`Unexpected timeout...`) instead of returning a failure result, mixing throw-based and return-based error handling within the same async operation."
+
+## Change Scope
+
+- `src/app/execute-retry/execute-attempt.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`


### PR DESCRIPTION
Emitted 2 event files documenting findings about the `typescripter` observer role.
1. `mixed_failure_semantics_typescripter.md` highlights the mixing of unrecoverable infrastructure errors and operational domain results (in `execute-attempt.ts` and `await-attempt-outcome.ts`).
2. `discriminated_union_deconstruction_typescripter.md` points out the issue of destructuring discriminated unions back into primitive types which enables unrepresentable states at the `shouldRetryFailure` boundary.

---
*PR created automatically by Jules for task [280022673376143521](https://jules.google.com/task/280022673376143521) started by @akitorahayashi*