### PR TITLE
Emit data architecture observer events

### DIFF
--- a/.jules/exchange/events/duplicate_result_models_data_arch.md
+++ b/.jules/exchange/events/duplicate_result_models_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-27"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Duplicate definitions exist for representing execution outcomes, violating the Single Source of Truth principle.
+
+## Goal
+
+Unify the representations into a single domain concept representing an execution attempt outcome.
+
+## Context
+
+The codebase defines `AttemptResult` in the core domain and `ExecutionResult` within an application module. Both structures are discriminated unions mapping to identical execution states (`success`, `error`, `timeout`) with the exact same inner properties (outcome, exitCode, stdout). This creates an unnecessary boundary conversion where the application module repackages identical concepts to the domain model without adding meaningful separation.
+
+## Evidence
+
+- path: "src/domain/result.ts"
+  loc: "1-18"
+  note: "Defines AttemptResult with outcome, exitCode, stdout, and attempt number."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "14-17"
+  note: "Defines ExecutionResult which mirrors AttemptResult sans the attempt number, leading to trivial mappings."
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "34-72"
+  note: "Maps ExecutionResult back to AttemptResult, showing the explicit conversion between identical state spaces."
+
+## Change Scope
+
+- `src/domain/result.ts`
+- `src/app/execute-retry/await-attempt-outcome.ts`
+- `src/app/execute-retry/execute-attempt.ts`

--- a/.jules/exchange/events/excessive_runtime_validation_data_arch.md
+++ b/.jules/exchange/events/excessive_runtime_validation_data_arch.md
@@ -1,0 +1,31 @@
+---
+label: "refacts"
+created_at: "2024-03-27"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Excessive and theoretically unreachable runtime validation exists where static types already enforce invariants.
+
+## Goal
+
+Remove defensive runtime checks that the type system statically prevents.
+
+## Context
+
+The `awaitAttemptOutcome` function returns a discriminated union `ExecutionResult`. When the `outcome` discriminant is `'success'`, the type system guarantees that `exitCode` is a `number`, not `null`. However, `executeAttempt` includes defensive runtime validation checking `result.exitCode === null` when `result.outcome === 'success'`, throwing an exception. This indicates a mistrust of the boundary contract and violates the principle of letting invariants be enforced natively by types.
+
+## Evidence
+
+- path: "src/app/execute-retry/execute-attempt.ts"
+  loc: "44-48"
+  note: "Defensive `if (result.exitCode === null)` runtime check throwing an Error despite `result.outcome === 'success'` narrowing."
+- path: "src/app/execute-retry/await-attempt-outcome.ts"
+  loc: "14-17"
+  note: "The type `ExecutionResult` guarantees `exitCode: number` when `outcome: 'success'`."
+
+## Change Scope
+
+- `src/app/execute-retry/execute-attempt.ts`

--- a/.jules/exchange/events/implicit_input_validation_data_arch.md
+++ b/.jules/exchange/events/implicit_input_validation_data_arch.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-03-27"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Input validation relies entirely on implicit panics/unwraps (throwing raw `Error` objects) instead of modeling invalid states via explicit error types or Result monads.
+
+## Goal
+
+Model boundary validation explicitly to prevent hidden control flow and unstructured error reporting.
+
+## Context
+
+The module responsible for reading and validating GitHub Action inputs, `readInputs()`, relies exclusively on throwing unstructured `Error` objects when invariants fail (e.g. required field missing, incorrect format, invalid boolean tokens). This violates the principle of explicit error modeling. The data boundary entry point accepts inputs but falls back to hidden control flow instead of returning an explicit parsing result, moving the burden of capturing and formatting validation issues to higher-level wrappers implicitly.
+
+## Evidence
+
+- path: "src/action/read-inputs.ts"
+  loc: "42"
+  note: "`readRequiredString` throws raw `Error` when missing."
+- path: "src/action/read-inputs.ts"
+  loc: "78"
+  note: "`parseInteger` throws `Error` on failed number regex."
+- path: "src/action/read-inputs.ts"
+  loc: "131"
+  note: "`readRetryOn` throws `Error` on invalid union values."
+
+## Change Scope
+
+- `src/action/read-inputs.ts`
+- `src/index.ts`


### PR DESCRIPTION
Emits event files from the perspective of a `data_arch` observer, detailing architectural and efficiency findings in the codebase related to data boundaries and validations.

### Changes
- Created `duplicate_result_models_data_arch.md` detailing identical models for `AttemptResult` and `ExecutionResult`.
- Created `excessive_runtime_validation_data_arch.md` addressing redundant runtime type checks.
- Created `implicit_input_validation_data_arch.md` outlining input validation that relies on unstructured Error exceptions.

---
*PR created automatically by Jules for task [3199686048264636511](https://jules.google.com/task/3199686048264636511) started by @akitorahayashi*