### PR TITLE
chore: Triage implementation-ready requirements

### DIFF
--- a/.jules/exchange/requirements/align_exit_code_format.md
+++ b/.jules/exchange/requirements/align_exit_code_format.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/cover_delay_adapter.md
+++ b/.jules/exchange/requirements/cover_delay_adapter.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/cover_entry_point.md
+++ b/.jules/exchange/requirements/cover_entry_point.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/cover_policy_default.md
+++ b/.jules/exchange/requirements/cover_policy_default.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/fix_delay_terminology.md
+++ b/.jules/exchange/requirements/fix_delay_terminology.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/remove_excessive_runtime_validation.md
+++ b/.jules/exchange/requirements/remove_excessive_runtime_validation.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal


### PR DESCRIPTION
Marked the following requirements as implementation ready:
- `align_exit_code_format.md`
- `cover_delay_adapter.md`
- `cover_entry_point.md`
- `cover_policy_default.md`
- `fix_delay_terminology.md`
- `remove_excessive_runtime_validation.md`

These match the criteria for small changes, such as single area tests, documentation alignment, or simple renames. Larger or multi-concern requirements remain `implementation_ready: false`.

---
*PR created automatically by Jules for task [7168025242180576843](https://jules.google.com/task/7168025242180576843) started by @akitorahayashi*