### PR TITLE
docs(consistency): emit observer events for documentation drift

### DIFF
--- a/.jules/exchange/events/final_stdout_consistency.md
+++ b/.jules/exchange/events/final_stdout_consistency.md
@@ -1,0 +1,32 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation in `docs/architecture/boundary.md` outlines the runtime execution flow and states that the action emits final outputs: `attempts`, `outcome`, `exit code`, and `succeeded`. However, it omits `final_stdout` which is also emitted by the action, as documented in `action.yml`, `docs/configuration/inputs.md`, and implemented in `src/action/emit-outputs.ts`.
+
+## Goal
+
+Ensure `final_stdout` is included in the runtime execution flow documentation to provide a complete and accurate list of emitted outputs.
+
+## Context
+
+In `docs/architecture/boundary.md` under "Runtime Execution Flow", the last step is "Emit final outputs with attempts, outcome, exit code, and succeeded". It misses `final_stdout`. Since documentation must reflect the current state and act as a contract, omitting a critical output in the architectural boundary documentation creates a mismatch.
+
+## Evidence
+
+- path: "docs/architecture/boundary.md"
+  loc: "line 20"
+  note: "The step 'Emit final outputs with attempts, outcome, exit code, and succeeded.' is missing 'final_stdout'."
+
+- path: "src/action/emit-outputs.ts"
+  loc: "line 12"
+  note: "`core.setOutput('final_stdout', result.stdout)` is emitted alongside the other outputs."
+
+## Change Scope
+
+- `docs/architecture/boundary.md`

--- a/.jules/exchange/events/silent_fallback_boolean_semantics_consistency.md
+++ b/.jules/exchange/events/silent_fallback_boolean_semantics_consistency.md
@@ -1,0 +1,33 @@
+---
+label: "docs"
+created_at: "2024-05-24"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The boundary documentation explicitly declares "No silent fallback paths are used" as a failure invariant. However, `readBooleanFlag` in the implementation silently falls back to `false` when an empty string is provided, bypassing the validation step without any explicit warning or error.
+
+## Goal
+
+Align the implementation's boolean parsing logic with the documented architectural constraint against silent fallbacks, or modify the boundary documentation to explicitly document this intentional fallback.
+
+## Context
+
+According to `docs/architecture/boundary.md`, the action fails explicitly when "required inputs are missing" or "numeric inputs are invalid", and it asserts that "No silent fallback paths are used". Yet, if an empty string is supplied for the boolean flag `continue_on_error` (e.g., dynamically through an action expression that evaluates to an empty value), the `readBooleanFlag` silently treats it as `false`. This violates the strict failure invariants set in the documentation.
+
+## Evidence
+
+- path: "docs/architecture/boundary.md"
+  loc: "line 45"
+  note: "Explicitly states 'No silent fallback paths are used.' under Failure Invariants."
+
+- path: "src/action/read-inputs.ts"
+  loc: "line 92"
+  note: "In `readBooleanFlag`, if the input is empty or missing (`!value`), it silently falls back to `return false` without failing validation or logging."
+
+## Change Scope
+
+- `docs/architecture/boundary.md`
+- `src/action/read-inputs.ts`


### PR DESCRIPTION
- Added `final_stdout_consistency.md` to document the missing `final_stdout` output in `docs/architecture/boundary.md`.
- Added `silent_fallback_boolean_semantics_consistency.md` to document the silent fallback to `false` in `readBooleanFlag` when an empty string is provided, which contradicts the boundary invariants documentation.

---
*PR created automatically by Jules for task [1434571018856541636](https://jules.google.com/task/1434571018856541636) started by @akitorahayashi*