### PR TITLE
test: add unit tests for delay adapter

### DIFF
--- a/tests/adapters/delay.test.ts
+++ b/tests/adapters/delay.test.ts
@@ -38,4 +38,32 @@ describe('delay', () => {
     await vi.advanceTimersByTimeAsync(1500)
     expect(resolved).toBe(false)
   })
+
+  it('resolves immediately for 0 milliseconds', async () => {
+    const { promise } = delay(0)
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(resolved).toBe(true)
+  })
+
+  it('does nothing when cancel is called after resolution', async () => {
+    const { promise, cancel } = delay(100)
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(resolved).toBe(true)
+
+    cancel()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(resolved).toBe(true)
+  })
 })

--- a/tests/adapters/delay.test.ts
+++ b/tests/adapters/delay.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { delay } from '../../src/adapters/delay'
+
+describe('delay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves after the specified milliseconds', async () => {
+    const { promise } = delay(1000)
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(500)
+    expect(resolved).toBe(true)
+  })
+
+  it('cancels the timeout when cancel is called', async () => {
+    const { promise, cancel } = delay(1000)
+    let resolved = false
+    promise.then(() => {
+      resolved = true
+    })
+
+    cancel()
+
+    await vi.advanceTimersByTimeAsync(1500)
+    expect(resolved).toBe(false)
+  })
+})


### PR DESCRIPTION
Ensured the `delay` adapter is fully covered by unit tests, correctly handling standard resolution and cancellation via the returned function.

# Fixes/Resolves
Fixes an issue with 0% function and 10% line test coverage on `src/adapters/delay.ts`.

# Testing Done
- Ran `npx vitest run tests/adapters/delay.test.ts --coverage` which reported 100% coverage on the targeted file.
- `vi.useFakeTimers()` were utilized to ensure tests don't take real time and safely isolated with `vi.useRealTimers()` in an `afterEach` hook.

---
*PR created automatically by Jules for task [9945318377284414404](https://jules.google.com/task/9945318377284414404) started by @akitorahayashi*