### PR TITLE
refactor: align missing exit code formatting to 'none' across domain

### DIFF
--- a/docs/configuration/inputs.md
+++ b/docs/configuration/inputs.md
@@ -24,7 +24,7 @@ The action emits:
 | Output | Meaning |
 |--------|---------|
 | `attempts` | Number of attempts that executed |
-| `final_exit_code` | Final command exit code, or empty when no code is available |
+| `final_exit_code` | Final command exit code, or `'none'` when no code is available |
 | `final_outcome` | Final attempt outcome (`success`, `error`, `timeout`) |
 | `succeeded` | `true` when any attempt succeeded, otherwise `false` |
 | `final_stdout` | Stdout emitted by the final attempt |

--- a/src/action/emit-outputs.ts
+++ b/src/action/emit-outputs.ts
@@ -1,12 +1,10 @@
 import * as core from '@actions/core'
+import { formatExitCode } from '../app/execute-retry/format-exit-code'
 import type { AttemptResult } from '../domain/result'
 
 export function emitOutputs(result: AttemptResult): void {
   core.setOutput('attempts', result.attempt)
-  core.setOutput(
-    'final_exit_code',
-    result.exitCode === null ? '' : String(result.exitCode),
-  )
+  core.setOutput('final_exit_code', formatExitCode(result.exitCode))
   core.setOutput('final_outcome', result.outcome)
   core.setOutput('succeeded', String(result.outcome === 'success'))
   core.setOutput('final_stdout', result.stdout)

--- a/tests/action/emit-outputs.test.ts
+++ b/tests/action/emit-outputs.test.ts
@@ -23,4 +23,21 @@ describe('emitOutputs', () => {
     expect(setOutput).toHaveBeenCalledWith('succeeded', 'true')
     expect(setOutput).toHaveBeenCalledWith('final_stdout', '{"ok":true}')
   })
+
+  it('emits "none" for final_exit_code when exitCode is null', () => {
+    const setOutput = vi.spyOn(core, 'setOutput').mockImplementation(() => {})
+
+    emitOutputs({
+      attempt: 1,
+      exitCode: null,
+      outcome: 'timeout',
+      stdout: '',
+    })
+
+    expect(setOutput).toHaveBeenCalledWith('attempts', 1)
+    expect(setOutput).toHaveBeenCalledWith('final_exit_code', 'none')
+    expect(setOutput).toHaveBeenCalledWith('final_outcome', 'timeout')
+    expect(setOutput).toHaveBeenCalledWith('succeeded', 'false')
+    expect(setOutput).toHaveBeenCalledWith('final_stdout', '')
+  })
 })


### PR DESCRIPTION
Align the string representation of a missing exit code (`null`) across the domain, logging, and outputs. The action output `final_exit_code` now emits `'none'` instead of an empty string `''`.

---
*PR created automatically by Jules for task [11888415603526156073](https://jules.google.com/task/11888415603526156073) started by @akitorahayashi*