### PR TITLE
Refactor input parsing to use explicit validation result monad

### DIFF
--- a/src/action/read-inputs.ts
+++ b/src/action/read-inputs.ts
@@ -1,6 +1,10 @@
 import * as core from '@actions/core'
 import type { RetryOn } from '../domain/policy'
 
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: string[] }
+
 export interface RetryRequest {
   command: string
   maxAttempts: number
@@ -14,34 +18,91 @@ export interface RetryRequest {
   terminationGraceSeconds: number
 }
 
-export function readInputs(): RetryRequest {
+export function readInputs(): ParseResult<RetryRequest> {
+  const errors: string[] = []
+
   const command = readRequiredString('command')
+  if (!command.ok) errors.push(...command.errors)
+
+  const maxAttempts = readRequiredInteger('max_attempts', { minimum: 1 })
+  if (!maxAttempts.ok) errors.push(...maxAttempts.errors)
+
+  const shell = readOptionalString('shell')
+
+  const timeoutSeconds = readOptionalInteger('timeout_seconds', { minimum: 1 })
+  if (!timeoutSeconds.ok) errors.push(...timeoutSeconds.errors)
+
+  const retryDelaySeconds = readOptionalInteger('retry_delay_seconds', {
+    minimum: 0,
+  })
+  if (!retryDelaySeconds.ok) errors.push(...retryDelaySeconds.errors)
+
+  const retryDelayScheduleSeconds = readIntegerList(
+    'retry_delay_schedule_seconds',
+    {
+      minimum: 0,
+    },
+  )
+  if (!retryDelayScheduleSeconds.ok)
+    errors.push(...retryDelayScheduleSeconds.errors)
+
+  const retryOn = readRetryOn('retry_on')
+  if (!retryOn.ok) errors.push(...retryOn.errors)
+
+  const retryOnExitCodes = readExitCodeSet('retry_on_exit_codes')
+  if (!retryOnExitCodes.ok) errors.push(...retryOnExitCodes.errors)
+
+  const continueOnError = readBooleanFlag('continue_on_error')
+  if (!continueOnError.ok) errors.push(...continueOnError.errors)
+
+  const terminationGraceSeconds = readOptionalInteger(
+    'termination_grace_seconds',
+    { minimum: 1 },
+  )
+  if (!terminationGraceSeconds.ok)
+    errors.push(...terminationGraceSeconds.errors)
+
+  if (errors.length > 0) {
+    return { ok: false, errors }
+  }
 
   return {
-    command,
-    maxAttempts: readRequiredInteger('max_attempts', { minimum: 1 }),
-    shell: readOptionalString('shell') ?? 'bash',
-    timeoutSeconds: readOptionalInteger('timeout_seconds', { minimum: 1 }),
-    retryDelaySeconds:
-      readOptionalInteger('retry_delay_seconds', { minimum: 0 }) ?? 0,
-    retryDelayScheduleSeconds: readIntegerList('retry_delay_schedule_seconds', {
-      minimum: 0,
-    }),
-    retryOn: readRetryOn('retry_on'),
-    retryOnExitCodes: readExitCodeSet('retry_on_exit_codes'),
-    continueOnError: readBooleanFlag('continue_on_error'),
-    terminationGraceSeconds:
-      readOptionalInteger('termination_grace_seconds', { minimum: 1 }) ?? 5,
+    ok: true,
+    value: {
+      command: (command as { ok: true; value: string }).value,
+      maxAttempts: (maxAttempts as { ok: true; value: number }).value,
+      shell: shell ?? 'bash',
+      timeoutSeconds: (
+        timeoutSeconds as { ok: true; value: number | undefined }
+      ).value,
+      retryDelaySeconds:
+        (retryDelaySeconds as { ok: true; value: number | undefined }).value ??
+        0,
+      retryDelayScheduleSeconds: (
+        retryDelayScheduleSeconds as { ok: true; value: number[] }
+      ).value,
+      retryOn: (retryOn as { ok: true; value: RetryOn }).value,
+      retryOnExitCodes: (
+        retryOnExitCodes as {
+          ok: true
+          value: ReadonlySet<number> | undefined
+        }
+      ).value,
+      continueOnError: (continueOnError as { ok: true; value: boolean }).value,
+      terminationGraceSeconds:
+        (terminationGraceSeconds as { ok: true; value: number | undefined })
+          .value ?? 5,
+    },
   }
 }
 
-function readRequiredString(name: string): string {
+function readRequiredString(name: string): ParseResult<string> {
   const value = core.getInput(name)
   const trimmed = value.trim()
   if (trimmed.length === 0) {
-    throw new Error(`Input '${name}' is required.`)
+    return { ok: false, errors: [`Input '${name}' is required.`] }
   }
-  return trimmed
+  return { ok: true, value: trimmed }
 }
 
 function readOptionalString(name: string): string | undefined {
@@ -53,10 +114,10 @@ function readOptionalString(name: string): string | undefined {
 function readOptionalInteger(
   name: string,
   options: { minimum: number },
-): number | undefined {
+): ParseResult<number | undefined> {
   const value = readOptionalString(name)
   if (!value) {
-    return undefined
+    return { ok: true, value: undefined }
   }
   return parseInteger(name, value, options)
 }
@@ -64,33 +125,39 @@ function readOptionalInteger(
 function readRequiredInteger(
   name: string,
   options: { minimum: number },
-): number {
-  const value = readRequiredString(name)
-  return parseInteger(name, value, options)
+): ParseResult<number> {
+  const valueResult = readRequiredString(name)
+  if (!valueResult.ok) {
+    return valueResult
+  }
+  return parseInteger(name, valueResult.value, options)
 }
 
 function parseInteger(
   name: string,
   value: string,
   options: { minimum: number },
-): number {
+): ParseResult<number> {
   if (!/^[-+]?\d+$/.test(value)) {
-    throw new Error(`Input '${name}' must be an integer.`)
+    return { ok: false, errors: [`Input '${name}' must be an integer.`] }
   }
 
   const parsed = Number.parseInt(value, 10)
 
   if (parsed < options.minimum) {
-    throw new Error(`Input '${name}' must be >= ${options.minimum}.`)
+    return {
+      ok: false,
+      errors: [`Input '${name}' must be >= ${options.minimum}.`],
+    }
   }
 
-  return parsed
+  return { ok: true, value: parsed }
 }
 
-function readBooleanFlag(name: string): boolean {
+function readBooleanFlag(name: string): ParseResult<boolean> {
   const value = readOptionalString(name)
   if (!value) {
-    return false
+    return { ok: true, value: false }
   }
 
   const normalized = value.toLowerCase()
@@ -100,23 +167,26 @@ function readBooleanFlag(name: string): boolean {
     case 'true':
     case 'yes':
     case 'on':
-      return true
+      return { ok: true, value: true }
     case '0':
     case 'false':
     case 'no':
     case 'off':
-      return false
+      return { ok: true, value: false }
     default:
-      throw new Error(
-        `Input '${name}' must be a boolean token: 1, 0, true, false, yes, no, on, off.`,
-      )
+      return {
+        ok: false,
+        errors: [
+          `Input '${name}' must be a boolean token: 1, 0, true, false, yes, no, on, off.`,
+        ],
+      }
   }
 }
 
-function readRetryOn(name: string): RetryOn {
+function readRetryOn(name: string): ParseResult<RetryOn> {
   const value = readOptionalString(name)
   if (!value) {
-    return 'any'
+    return { ok: true, value: 'any' }
   }
 
   const normalized = value.toLowerCase()
@@ -125,27 +195,54 @@ function readRetryOn(name: string): RetryOn {
     normalized === 'error' ||
     normalized === 'timeout'
   ) {
-    return normalized
+    return { ok: true, value: normalized as RetryOn }
   }
 
-  throw new Error("Input 'retry_on' must be one of: any, error, timeout.")
+  return {
+    ok: false,
+    errors: ["Input 'retry_on' must be one of: any, error, timeout."],
+  }
 }
 
-function readIntegerList(name: string, options: { minimum: number }): number[] {
+function readIntegerList(
+  name: string,
+  options: { minimum: number },
+): ParseResult<number[]> {
   const value = readOptionalString(name)
   if (!value) {
-    return []
+    return { ok: true, value: [] }
   }
 
-  return value
-    .split(',')
-    .map((item) => parseInteger(name, item.trim(), options))
+  const items = value.split(',').map((item) => item.trim())
+  const parsedItems: number[] = []
+  const errors: string[] = []
+
+  for (const item of items) {
+    const parsed = parseInteger(name, item, options)
+    if (parsed.ok) {
+      parsedItems.push(parsed.value)
+    } else {
+      errors.push(...parsed.errors)
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors }
+  }
+
+  return { ok: true, value: parsedItems }
 }
 
-function readExitCodeSet(name: string): ReadonlySet<number> | undefined {
-  const values = readIntegerList(name, { minimum: 0 })
-  if (values.length === 0) {
-    return undefined
+function readExitCodeSet(
+  name: string,
+): ParseResult<ReadonlySet<number> | undefined> {
+  const valuesResult = readIntegerList(name, { minimum: 0 })
+  if (!valuesResult.ok) {
+    return valuesResult
   }
-  return new Set(values)
+
+  if (valuesResult.value.length === 0) {
+    return { ok: true, value: undefined }
+  }
+  return { ok: true, value: new Set(valuesResult.value) }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import { readInputs } from './action/read-inputs'
 import { executeRetry } from './app/execute-retry'
 
 async function run(): Promise<void> {
-  const request = readInputs()
+  const requestResult = readInputs()
+  if (!requestResult.ok) {
+    core.setFailed(requestResult.errors.join('\n'))
+    return
+  }
+  const request = requestResult.value
+
   const result = await executeRetry({
     command: {
       command: request.command,

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -26,16 +26,19 @@ describe('readInputs', () => {
     })
 
     expect(readInputs()).toEqual({
-      command: 'npm test',
-      maxAttempts: 3,
-      shell: 'bash',
-      timeoutSeconds: undefined,
-      retryDelaySeconds: 0,
-      retryDelayScheduleSeconds: [],
-      retryOn: 'any',
-      retryOnExitCodes: undefined,
-      continueOnError: false,
-      terminationGraceSeconds: 5,
+      ok: true,
+      value: {
+        command: 'npm test',
+        maxAttempts: 3,
+        shell: 'bash',
+        timeoutSeconds: undefined,
+        retryDelaySeconds: 0,
+        retryDelayScheduleSeconds: [],
+        retryOn: 'any',
+        retryOnExitCodes: undefined,
+        continueOnError: false,
+        terminationGraceSeconds: 5,
+      },
     })
   })
 
@@ -68,33 +71,41 @@ describe('readInputs', () => {
     })
 
     const result = readInputs()
-    expect(result.retryOnExitCodes).toEqual(new Set([1, 2, 9]))
     expect(result).toEqual({
-      command: 'npm run check',
-      maxAttempts: 5,
-      shell: '/bin/bash',
-      timeoutSeconds: 15,
-      retryDelaySeconds: 3,
-      retryDelayScheduleSeconds: [1, 2, 5],
-      retryOn: 'error',
-      retryOnExitCodes: new Set([1, 2, 9]),
-      continueOnError: true,
-      terminationGraceSeconds: 2,
+      ok: true,
+      value: {
+        command: 'npm run check',
+        maxAttempts: 5,
+        shell: '/bin/bash',
+        timeoutSeconds: 15,
+        retryDelaySeconds: 3,
+        retryDelayScheduleSeconds: [1, 2, 5],
+        retryOn: 'error',
+        retryOnExitCodes: new Set([1, 2, 9]),
+        continueOnError: true,
+        terminationGraceSeconds: 2,
+      },
     })
   })
 
-  it('throws when required command is missing', () => {
+  it('returns error when required command is missing', () => {
     mockedGetInput.mockImplementation((name: string) => {
       if (name === 'command') {
         return ' '
       }
-      return '1'
+      if (name === 'max_attempts') {
+        return '1'
+      }
+      return ''
     })
 
-    expect(() => readInputs()).toThrow("Input 'command' is required.")
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: ["Input 'command' is required."],
+    })
   })
 
-  it('throws for invalid retry_on value', () => {
+  it('returns error for invalid retry_on value', () => {
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
         case 'command':
@@ -108,12 +119,13 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow(
-      "Input 'retry_on' must be one of: any, error, timeout.",
-    )
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: ["Input 'retry_on' must be one of: any, error, timeout."],
+    })
   })
 
-  it('throws when numeric value violates minimum', () => {
+  it('returns error when numeric value violates minimum', () => {
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
         case 'command':
@@ -125,10 +137,13 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow("Input 'max_attempts' must be >= 1.")
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: ["Input 'max_attempts' must be >= 1."],
+    })
   })
 
-  it('throws when numeric value is not an integer', () => {
+  it('returns error when numeric value is not an integer', () => {
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
         case 'command':
@@ -142,9 +157,13 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow(
-      "Input 'max_attempts' must be an integer.",
-    )
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: [
+        "Input 'max_attempts' must be an integer.",
+        "Input 'timeout_seconds' must be an integer.",
+      ],
+    })
 
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
@@ -159,9 +178,10 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow(
-      "Input 'timeout_seconds' must be an integer.",
-    )
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: ["Input 'timeout_seconds' must be an integer."],
+    })
 
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
@@ -176,9 +196,10 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow(
-      "Input 'retry_delay_seconds' must be an integer.",
-    )
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: ["Input 'retry_delay_seconds' must be an integer."],
+    })
   })
 
   it.each([
@@ -211,10 +232,13 @@ describe('readInputs', () => {
     })
 
     const result = readInputs()
-    expect(result.continueOnError).toBe(expected)
+    if (!result.ok) {
+      throw new Error(`Expected successful parse, got errors: ${result.errors}`)
+    }
+    expect(result.value.continueOnError).toBe(expected)
   })
 
-  it('throws when continue_on_error uses invalid boolean token', () => {
+  it('returns error when continue_on_error uses invalid boolean token', () => {
     mockedGetInput.mockImplementation((name: string) => {
       switch (name) {
         case 'command':
@@ -228,8 +252,11 @@ describe('readInputs', () => {
       }
     })
 
-    expect(() => readInputs()).toThrow(
-      "Input 'continue_on_error' must be a boolean token: 1, 0, true, false, yes, no, on, off.",
-    )
+    expect(readInputs()).toEqual({
+      ok: false,
+      errors: [
+        "Input 'continue_on_error' must be a boolean token: 1, 0, true, false, yes, no, on, off.",
+      ],
+    })
   })
 })


### PR DESCRIPTION
Refactored configuration input parsing to use an explicit discriminated union Result type (`ParseResult`), eliminating thrown errors from `readInputs`. Input validation aggregates all explicit failures instead. Entrypoints correctly check and map these validation payloads to fail status messages. Unit tests were updated to assert behavior on this explicit observable boundary instead of testing for internal exception handling. This improves correctness of error reporting.

---
*PR created automatically by Jules for task [14026975901433239168](https://jules.google.com/task/14026975901433239168) started by @akitorahayashi*