### PR TITLE
Refactor: Extract test setups into domain-specific shared test fixtures

### DIFF
--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -4,8 +4,10 @@ import {
   logAttemptCompletion,
 } from '../../src/app/execute-retry/await-attempt-outcome'
 import * as core from '@actions/core'
-import type { RunningCommand } from '../../src/adapters/run-shell-command'
-import type { CommandSpec } from '../../src/domain/command'
+import {
+  createCommandSpec,
+  createRunningCommand,
+} from '../fixtures/execute-retry-fixtures'
 
 describe('awaitAttemptOutcome', () => {
   beforeEach(() => {
@@ -13,17 +15,10 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns success when process completes without timeout', async () => {
-    const command: CommandSpec = {
-      command: 'echo "test"',
-      shell: 'bash',
-      timeoutSeconds: undefined,
-      terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: 'ok\n' }),
-    }
+    const command = createCommandSpec()
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 0, stdout: 'ok\n' }),
+    )
     const dependencies = {
       delay: vi.fn(),
       terminateProcessTree: vi.fn(),
@@ -40,17 +35,10 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('throws error when process unexpectedly times out despite timeoutSeconds being undefined', async () => {
-    const command: CommandSpec = {
-      command: 'echo "test"',
-      shell: 'bash',
-      timeoutSeconds: undefined,
-      terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: null, stdout: '' }),
-    }
+    const command = createCommandSpec()
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: null, stdout: '' }),
+    )
 
     // To simulate completion resolving to a timeout outcome natively,
     // we use `Object.defineProperty` or `vi.spyOn` on the promise `then`.
@@ -76,17 +64,10 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns error when process completes with non-zero exit code without timeout', async () => {
-    const command: CommandSpec = {
-      command: 'exit 1',
-      shell: 'bash',
-      timeoutSeconds: undefined,
-      terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 1, stdout: 'failed\n' }),
-    }
+    const command = createCommandSpec({ command: 'exit 1' })
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 1, stdout: 'failed\n' }),
+    )
     const dependencies = {
       delay: vi.fn(),
       terminateProcessTree: vi.fn(),
@@ -107,17 +88,10 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns success when process completes before timeout', async () => {
-    const command: CommandSpec = {
-      command: 'echo "test"',
-      shell: 'bash',
-      timeoutSeconds: 10,
-      terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '{"ok":true}' }),
-    }
+    const command = createCommandSpec({ timeoutSeconds: 10 })
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 0, stdout: '{"ok":true}' }),
+    )
     const cancelTimeout = vi.fn()
 
     // Create a resolvable promise to represent a delay that never triggered before completion
@@ -156,26 +130,21 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('terminates process tree when timeout is reached', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
-      terminationGraceSeconds: 5,
-    }
+    })
     let resolveCompletion!: (value: {
-      exitCode: number
+      exitCode: number | null
       stdout: string
     }) => void
-    const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => {
-        resolveCompletion = resolve
-      },
-    )
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const completionPromise = new Promise<{
+      exitCode: number | null
+      stdout: string
+    }>((resolve) => {
+      resolveCompletion = resolve
+    })
+    const runningCommand = createRunningCommand(completionPromise)
 
     let resolveInitialTimeout!: () => void
     const initialTimeoutPromise = new Promise<void>((resolve) => {
@@ -247,28 +216,23 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('throws when terminateProcessTree fails with Error', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
-      terminationGraceSeconds: 5,
-    }
+    })
 
     let resolveCompletion!: (value: {
-      exitCode: number
+      exitCode: number | null
       stdout: string
     }) => void
-    const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => {
-        resolveCompletion = resolve
-      },
-    )
+    const completionPromise = new Promise<{
+      exitCode: number | null
+      stdout: string
+    }>((resolve) => {
+      resolveCompletion = resolve
+    })
 
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(completionPromise)
 
     const cancelTimeout = vi.fn()
     let resolveTerminationDelay!: () => void
@@ -305,28 +269,23 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('throws when terminateProcessTree fails with a non-Error value', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
-      terminationGraceSeconds: 5,
-    }
+    })
 
     let resolveCompletion!: (value: {
-      exitCode: number
+      exitCode: number | null
       stdout: string
     }) => void
-    const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => {
-        resolveCompletion = resolve
-      },
-    )
+    const completionPromise = new Promise<{
+      exitCode: number | null
+      stdout: string
+    }>((resolve) => {
+      resolveCompletion = resolve
+    })
 
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(completionPromise)
 
     let resolveTerminationDelay!: () => void
     const terminationDelayPromise = new Promise<void>((resolve) => {
@@ -362,28 +321,23 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns a safe outcome without exit code if termination fallback timeout triggers', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
-      terminationGraceSeconds: 5,
-    }
+    })
 
     let resolveCompletion!: (value: {
-      exitCode: number
+      exitCode: number | null
       stdout: string
     }) => void
-    const completionPromise = new Promise<{ exitCode: number; stdout: string }>(
-      (resolve) => {
-        resolveCompletion = resolve
-      },
-    )
+    const completionPromise = new Promise<{
+      exitCode: number | null
+      stdout: string
+    }>((resolve) => {
+      resolveCompletion = resolve
+    })
 
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(completionPromise)
 
     const dependencies = {
       delay: vi

--- a/tests/app/execute-attempt.test.ts
+++ b/tests/app/execute-attempt.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { executeAttempt } from '../../src/app/execute-retry/execute-attempt'
 import type { ExecuteRetryDependencies } from '../../src/app/execute-retry/execute-retry-dependencies'
-import type { CommandSpec } from '../../src/domain/command'
 import type { ExecutionResult } from '../../src/app/execute-retry/await-attempt-outcome'
 import * as awaitAttemptOutcomeModule from '../../src/app/execute-retry/await-attempt-outcome'
+import {
+  createCommandSpec,
+  createCompletedCommand,
+} from '../fixtures/execute-retry-fixtures'
 
 vi.mock(
   '../../src/app/execute-retry/await-attempt-outcome',
@@ -22,19 +25,10 @@ describe('executeAttempt', () => {
   })
 
   it('coerces impossible success-with-null-exitCode into an error outcome', async () => {
-    const command: CommandSpec = {
-      command: 'echo "test"',
-      shell: 'bash',
-      timeoutSeconds: undefined,
-      terminationGraceSeconds: 5,
-    }
+    const command = createCommandSpec()
 
     const dependencies: ExecuteRetryDependencies = {
-      runCommand: vi.fn().mockReturnValue({
-        pid: 1234,
-        completion: Promise.resolve({ exitCode: null, stdout: '' }),
-        isRunning: () => false,
-      }),
+      runCommand: vi.fn().mockReturnValue(createCompletedCommand(null, '')),
       delay: vi.fn(),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
     }

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -1,62 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { RunningCommand } from '../../src/adapters/run-shell-command'
+import { executeRetry } from '../../src/app/execute-retry'
 import {
-  executeRetry,
-  type ExecuteRetryRequest,
-} from '../../src/app/execute-retry'
-
-interface ExecuteRetryRequestOverrides {
-  maxAttempts?: ExecuteRetryRequest['maxAttempts']
-  command?: Partial<ExecuteRetryRequest['command']>
-  policy?: Partial<ExecuteRetryRequest['policy']>
-  schedule?: Partial<ExecuteRetryRequest['schedule']>
-}
-
-function createRequest(
-  overrides?: ExecuteRetryRequestOverrides,
-): ExecuteRetryRequest {
-  const defaultCommand = {
-    command: 'echo test',
-    shell: 'bash',
-    timeoutSeconds: undefined,
-    terminationGraceSeconds: 1,
-    ...(overrides?.command || {}),
-  }
-
-  const defaultPolicy = {
-    retryOn: 'any' as const,
-    retryOnExitCodes: undefined,
-    ...(overrides?.policy || {}),
-  }
-
-  const defaultSchedule = {
-    retryDelaySeconds: 0,
-    retryDelayScheduleSeconds: [],
-    ...(overrides?.schedule || {}),
-  }
-
-  return {
-    maxAttempts: overrides?.maxAttempts ?? 3,
-    command: defaultCommand,
-    policy: defaultPolicy,
-    schedule: defaultSchedule,
-  }
-}
-
-function completed(exitCode: number | null, stdout = ''): RunningCommand {
-  return {
-    pid: 100,
-    completion: Promise.resolve({ exitCode, stdout }),
-    isRunning: () => false,
-  }
-}
-
-function createNeverDelay() {
-  return {
-    promise: new Promise<void>(() => {}),
-    cancel: vi.fn(),
-  }
-}
+  createExecuteRetryRequest,
+  createCompletedCommand,
+  createNeverDelay,
+} from '../fixtures/execute-retry-fixtures'
 
 describe('executeRetry', () => {
   it('returns timeout and terminates process tree when timeout wins', async () => {
@@ -81,7 +29,7 @@ describe('executeRetry', () => {
     })
 
     const result = await executeRetry(
-      createRequest({
+      createExecuteRetryRequest({
         maxAttempts: 1,
         command: {
           timeoutSeconds: 5,
@@ -149,11 +97,14 @@ describe('executeRetry', () => {
       isRunning: () => true,
     })
 
-    const resultPromise = executeRetry(createRequest({ maxAttempts: 1 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree,
-    })
+    const resultPromise = executeRetry(
+      createExecuteRetryRequest({ maxAttempts: 1 }),
+      {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree,
+      },
+    )
 
     const signalCall = processOnceSpy.mock.calls.find(
       (call) => call[0] === signal,
@@ -180,10 +131,10 @@ describe('executeRetry', () => {
   it('stops when one attempt succeeds', async () => {
     const runCommand = vi
       .fn()
-      .mockReturnValueOnce(completed(1, 'first attempt\n'))
-      .mockReturnValueOnce(completed(0, '{"ok":true}'))
+      .mockReturnValueOnce(createCompletedCommand(1, 'first attempt\n'))
+      .mockReturnValueOnce(createCompletedCommand(0, '{"ok":true}'))
 
-    const result = await executeRetry(createRequest(), {
+    const result = await executeRetry(createExecuteRetryRequest(), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
@@ -199,10 +150,10 @@ describe('executeRetry', () => {
   })
 
   it('stops without retry when policy excludes error failures', async () => {
-    const runCommand = vi.fn().mockReturnValue(completed(9))
+    const runCommand = vi.fn().mockReturnValue(createCompletedCommand(9))
 
     const result = await executeRetry(
-      createRequest({ policy: { retryOn: 'timeout' } }),
+      createExecuteRetryRequest({ policy: { retryOn: 'timeout' } }),
       {
         runCommand,
         delay: vi.fn().mockReturnValue(createNeverDelay()),
@@ -222,11 +173,13 @@ describe('executeRetry', () => {
   it('retries only configured exit codes when filter is provided', async () => {
     const runCommand = vi
       .fn()
-      .mockReturnValueOnce(completed(2))
-      .mockReturnValueOnce(completed(3))
+      .mockReturnValueOnce(createCompletedCommand(2))
+      .mockReturnValueOnce(createCompletedCommand(3))
 
     const result = await executeRetry(
-      createRequest({ policy: { retryOnExitCodes: new Set([2, 7]) } }),
+      createExecuteRetryRequest({
+        policy: { retryOnExitCodes: new Set([2, 7]) },
+      }),
       {
         runCommand,
         delay: vi.fn().mockReturnValue(createNeverDelay()),
@@ -246,9 +199,9 @@ describe('executeRetry', () => {
   it('applies scheduled retry delay values ahead of fixed delay', async () => {
     const runCommand = vi
       .fn()
-      .mockReturnValueOnce(completed(1))
-      .mockReturnValueOnce(completed(2))
-      .mockReturnValueOnce(completed(3))
+      .mockReturnValueOnce(createCompletedCommand(1))
+      .mockReturnValueOnce(createCompletedCommand(2))
+      .mockReturnValueOnce(createCompletedCommand(3))
 
     const delayFn = vi.fn().mockImplementation((ms) => {
       // If ms is not a small sleep, it's likely a timeout or not our expected sleep
@@ -262,7 +215,7 @@ describe('executeRetry', () => {
     })
 
     const result = await executeRetry(
-      createRequest({
+      createExecuteRetryRequest({
         schedule: {
           retryDelaySeconds: 10,
           retryDelayScheduleSeconds: [1, 5],
@@ -285,11 +238,14 @@ describe('executeRetry', () => {
       throw new Error('spawn failed')
     })
 
-    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
-    })
+    const result = await executeRetry(
+      createExecuteRetryRequest({ maxAttempts: 2 }),
+      {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+      },
+    )
 
     expect(result).toEqual({
       attempt: 2,
@@ -308,11 +264,14 @@ describe('executeRetry', () => {
       isRunning: () => false,
     })
 
-    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
-    })
+    const result = await executeRetry(
+      createExecuteRetryRequest({ maxAttempts: 2 }),
+      {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+      },
+    )
 
     expect(result).toEqual({
       attempt: 2,

--- a/tests/app/terminate-command-on-signal.test.ts
+++ b/tests/app/terminate-command-on-signal.test.ts
@@ -1,34 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { registerCommandTerminationOnSignal } from '../../src/app/execute-retry/terminate-command-on-signal'
-import type { RunningCommand } from '../../src/adapters/run-shell-command'
-
-function createProcessSpies() {
-  let resolveExit!: (code: number) => void
-  const exitDone = new Promise<number>((resolve) => {
-    resolveExit = resolve
-  })
-
-  return {
-    once: vi.spyOn(process, 'once').mockReturnThis(),
-    off: vi.spyOn(process, 'off').mockReturnThis(),
-    exit: vi
-      .spyOn(process, 'exit')
-      .mockImplementation((code?: number | string | null) => {
-        resolveExit(Number(code))
-        return undefined as never
-      }),
-    exitDone,
-  }
-}
-
-function findSignalHandler(
-  calls: ReadonlyArray<ReadonlyArray<unknown>>,
-  signal: 'SIGTERM' | 'SIGINT',
-): (() => void) | undefined {
-  return calls.find((call) => call[0] === signal)?.[1] as
-    | (() => void)
-    | undefined
-}
+import { createRunningCommand } from '../fixtures/execute-retry-fixtures'
+import {
+  createProcessSpies,
+  findSignalHandler,
+} from '../fixtures/process-fixtures'
 
 describe('registerCommandTerminationOnSignal', () => {
   beforeEach(() => {
@@ -95,11 +71,9 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('terminates process tree and exits with 0 on SIGTERM', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 0, stdout: '' }),
+    )
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),
@@ -169,11 +143,9 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('catches non-Error from terminateProcessTree and exits with 0', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 0, stdout: '' }),
+    )
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),
@@ -197,11 +169,9 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('terminates process tree and exits with 0 on SIGINT', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 0, stdout: '' }),
+    )
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),
@@ -225,11 +195,9 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('catches terminateProcessTree error and exits with 0', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createRunningCommand(
+      Promise.resolve({ exitCode: 0, stdout: '' }),
+    )
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),

--- a/tests/fixtures/execute-retry-fixtures.ts
+++ b/tests/fixtures/execute-retry-fixtures.ts
@@ -1,0 +1,83 @@
+import { vi } from 'vitest'
+import type { RunningCommand } from '../../src/adapters/run-shell-command'
+import type { ExecuteRetryRequest } from '../../src/app/execute-retry'
+import type { CommandSpec } from '../../src/domain/command'
+
+interface ExecuteRetryRequestOverrides {
+  maxAttempts?: ExecuteRetryRequest['maxAttempts']
+  command?: Partial<ExecuteRetryRequest['command']>
+  policy?: Partial<ExecuteRetryRequest['policy']>
+  schedule?: Partial<ExecuteRetryRequest['schedule']>
+}
+
+export function createExecuteRetryRequest(
+  overrides?: ExecuteRetryRequestOverrides,
+): ExecuteRetryRequest {
+  const defaultCommand = {
+    command: 'echo test',
+    shell: 'bash',
+    timeoutSeconds: undefined,
+    terminationGraceSeconds: 1,
+    ...(overrides?.command || {}),
+  }
+
+  const defaultPolicy = {
+    retryOn: 'any' as const,
+    retryOnExitCodes: undefined,
+    ...(overrides?.policy || {}),
+  }
+
+  const defaultSchedule = {
+    retryDelaySeconds: 0,
+    retryDelayScheduleSeconds: [],
+    ...(overrides?.schedule || {}),
+  }
+
+  return {
+    maxAttempts: overrides?.maxAttempts ?? 3,
+    command: defaultCommand,
+    policy: defaultPolicy,
+    schedule: defaultSchedule,
+  }
+}
+
+export function createCompletedCommand(
+  exitCode: number | null,
+  stdout = '',
+): RunningCommand {
+  return {
+    pid: 100,
+    completion: Promise.resolve({ exitCode, stdout }),
+    isRunning: () => false,
+  }
+}
+
+export function createNeverDelay() {
+  return {
+    promise: new Promise<void>(() => {}),
+    cancel: vi.fn(),
+  }
+}
+
+export function createCommandSpec(
+  overrides?: Partial<CommandSpec>,
+): CommandSpec {
+  return {
+    command: 'echo "test"',
+    shell: 'bash',
+    timeoutSeconds: undefined,
+    terminationGraceSeconds: 5,
+    ...overrides,
+  }
+}
+
+export function createRunningCommand(
+  completionPromise: Promise<{ exitCode: number | null; stdout: string }>,
+  pid = 1234,
+): RunningCommand {
+  return {
+    pid,
+    isRunning: () => true,
+    completion: completionPromise,
+  }
+}

--- a/tests/fixtures/process-fixtures.ts
+++ b/tests/fixtures/process-fixtures.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest'
+
+export function createProcessSpies() {
+  let resolveExit!: (code: number) => void
+  const exitDone = new Promise<number>((resolve) => {
+    resolveExit = resolve
+  })
+
+  return {
+    once: vi.spyOn(process, 'once').mockReturnThis(),
+    off: vi.spyOn(process, 'off').mockReturnThis(),
+    exit: vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: number | string | null) => {
+        resolveExit(Number(code))
+        return undefined as never
+      }),
+    exitDone,
+  }
+}
+
+export function findSignalHandler(
+  calls: ReadonlyArray<ReadonlyArray<unknown>>,
+  signal: 'SIGTERM' | 'SIGINT',
+): (() => void) | undefined {
+  return calls.find((call) => call[0] === signal)?.[1] as
+    | (() => void)
+    | undefined
+}


### PR DESCRIPTION
Refactored application tests to utilize shared mock fixtures for testing. Moved inline mock factories from individual tests (`execute-retry.test.ts`, `await-attempt-outcome.test.ts`, `execute-attempt.test.ts`, `terminate-command-on-signal.test.ts`) into `tests/fixtures/execute-retry-fixtures.ts` and `tests/fixtures/process-fixtures.ts`. All usages updated. No application logic changed. Removed old structures cleanly. Tests, linting, and typechecks pass.

---
*PR created automatically by Jules for task [15388291908986910476](https://jules.google.com/task/15388291908986910476) started by @akitorahayashi*