### PR TITLE
Refactor delay terminology to clearly distinguish attempt delays

### DIFF
--- a/src/app/execute-retry/index.ts
+++ b/src/app/execute-retry/index.ts
@@ -4,7 +4,7 @@ import type { RetryPolicy } from '../../domain/policy'
 import { shouldRetryFailure } from '../../domain/policy'
 import type { AttemptResult } from '../../domain/result'
 import {
-  resolveRetryDelaySeconds,
+  resolveAttemptDelaySeconds,
   type RetrySchedule,
 } from '../../domain/schedule'
 import {
@@ -52,15 +52,15 @@ export async function executeRetry(
       return finalAttempt
     }
 
-    const delaySeconds = resolveRetryDelaySeconds(attempt, schedule)
+    const attemptDelaySeconds = resolveAttemptDelaySeconds(attempt, schedule)
 
     core.warning(
       `Attempt ${attempt} failed with ${finalAttempt.outcome} (exit code: ${formatExitCode(finalAttempt.exitCode)}). Retrying.`,
     )
 
-    if (delaySeconds > 0) {
-      core.info(`Waiting ${delaySeconds}s before next attempt.`)
-      await dependencies.delay(delaySeconds * 1000).promise
+    if (attemptDelaySeconds > 0) {
+      core.info(`Waiting ${attemptDelaySeconds}s before next attempt.`)
+      await dependencies.delay(attemptDelaySeconds * 1000).promise
     }
   }
 

--- a/src/domain/schedule.ts
+++ b/src/domain/schedule.ts
@@ -3,7 +3,7 @@ export interface RetrySchedule {
   retryDelayScheduleSeconds: readonly number[]
 }
 
-export function resolveRetryDelaySeconds(
+export function resolveAttemptDelaySeconds(
   attempt: number,
   schedule: RetrySchedule,
 ): number {

--- a/tests/domain/schedule.test.ts
+++ b/tests/domain/schedule.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { resolveRetryDelaySeconds } from '../../src/domain/schedule'
+import { resolveAttemptDelaySeconds } from '../../src/domain/schedule'
 
-describe('resolveRetryDelaySeconds', () => {
+describe('resolveAttemptDelaySeconds', () => {
   it('uses schedule value for matching attempt', () => {
     expect(
-      resolveRetryDelaySeconds(1, {
+      resolveAttemptDelaySeconds(1, {
         retryDelaySeconds: 10,
         retryDelayScheduleSeconds: [2, 4],
       }),
@@ -13,7 +13,7 @@ describe('resolveRetryDelaySeconds', () => {
 
   it('falls back to default delay when schedule has no value', () => {
     expect(
-      resolveRetryDelaySeconds(3, {
+      resolveAttemptDelaySeconds(3, {
         retryDelaySeconds: 10,
         retryDelayScheduleSeconds: [2, 4],
       }),


### PR DESCRIPTION
This PR addresses an issue where the terminology for "delay" concepts was inconsistent. It ensures that "delay" consistently conveys whether it is the user-configured retry delay, the calculated delay for the current attempt, or the primitive wait operation.

- Renames `resolveRetryDelaySeconds` to `resolveAttemptDelaySeconds`.
- Renames `delaySeconds` to `attemptDelaySeconds` where applicable.
- Keeps configuration keys intact.

---
*PR created automatically by Jules for task [3934265367695281427](https://jules.google.com/task/3934265367695281427) started by @akitorahayashi*