### PR TITLE
Refactor: Extract test fixtures into domain-specific modules

### DIFF
--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -4,8 +4,11 @@ import {
   logAttemptCompletion,
 } from '../../src/app/execute-retry/await-attempt-outcome'
 import * as core from '@actions/core'
-import type { RunningCommand } from '../../src/adapters/run-shell-command'
-import type { CommandSpec } from '../../src/domain/command'
+import {
+  createCommandSpec,
+  createCompletedCommand,
+  createRunningCommand,
+} from '../fixtures/execute-retry-fixtures'
 
 describe('awaitAttemptOutcome', () => {
   beforeEach(() => {
@@ -13,17 +16,14 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns success when process completes without timeout', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'echo "test"',
-      shell: 'bash',
       timeoutSeconds: undefined,
       terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: 'ok\n' }),
-    }
+    })
+    const runningCommand = createCompletedCommand(0, 'ok\n')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
     const dependencies = {
       delay: vi.fn(),
       terminateProcessTree: vi.fn(),
@@ -40,17 +40,14 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('throws error when process unexpectedly times out despite timeoutSeconds being undefined', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'echo "test"',
-      shell: 'bash',
       timeoutSeconds: undefined,
       terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: null, stdout: '' }),
-    }
+    })
+    const runningCommand = createCompletedCommand(null, '')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
 
     // To simulate completion resolving to a timeout outcome natively,
     // we use `Object.defineProperty` or `vi.spyOn` on the promise `then`.
@@ -76,17 +73,14 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns error when process completes with non-zero exit code without timeout', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'exit 1',
-      shell: 'bash',
       timeoutSeconds: undefined,
       terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 1, stdout: 'failed\n' }),
-    }
+    })
+    const runningCommand = createCompletedCommand(1, 'failed\n')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
     const dependencies = {
       delay: vi.fn(),
       terminateProcessTree: vi.fn(),
@@ -107,17 +101,14 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns success when process completes before timeout', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'echo "test"',
-      shell: 'bash',
       timeoutSeconds: 10,
       terminationGraceSeconds: 5,
-    }
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '{"ok":true}' }),
-    }
+    })
+    const runningCommand = createCompletedCommand(0, '{"ok":true}')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
     const cancelTimeout = vi.fn()
 
     // Create a resolvable promise to represent a delay that never triggered before completion
@@ -156,12 +147,11 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('terminates process tree when timeout is reached', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
       terminationGraceSeconds: 5,
-    }
+    })
     let resolveCompletion!: (value: {
       exitCode: number
       stdout: string
@@ -171,11 +161,7 @@ describe('awaitAttemptOutcome', () => {
         resolveCompletion = resolve
       },
     )
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(1234, completionPromise)
 
     let resolveInitialTimeout!: () => void
     const initialTimeoutPromise = new Promise<void>((resolve) => {
@@ -247,12 +233,11 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('throws when terminateProcessTree fails with Error', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
       terminationGraceSeconds: 5,
-    }
+    })
 
     let resolveCompletion!: (value: {
       exitCode: number
@@ -264,11 +249,7 @@ describe('awaitAttemptOutcome', () => {
       },
     )
 
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(1234, completionPromise)
 
     const cancelTimeout = vi.fn()
     let resolveTerminationDelay!: () => void
@@ -305,12 +286,11 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('throws when terminateProcessTree fails with a non-Error value', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
       terminationGraceSeconds: 5,
-    }
+    })
 
     let resolveCompletion!: (value: {
       exitCode: number
@@ -322,11 +302,7 @@ describe('awaitAttemptOutcome', () => {
       },
     )
 
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(1234, completionPromise)
 
     let resolveTerminationDelay!: () => void
     const terminationDelayPromise = new Promise<void>((resolve) => {
@@ -362,12 +338,11 @@ describe('awaitAttemptOutcome', () => {
   })
 
   it('returns a safe outcome without exit code if termination fallback timeout triggers', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'sleep 10',
-      shell: 'bash',
       timeoutSeconds: 1,
       terminationGraceSeconds: 5,
-    }
+    })
 
     let resolveCompletion!: (value: {
       exitCode: number
@@ -379,11 +354,7 @@ describe('awaitAttemptOutcome', () => {
       },
     )
 
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: completionPromise,
-    }
+    const runningCommand = createRunningCommand(1234, completionPromise)
 
     const dependencies = {
       delay: vi

--- a/tests/app/execute-attempt.test.ts
+++ b/tests/app/execute-attempt.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { executeAttempt } from '../../src/app/execute-retry/execute-attempt'
 import type { ExecuteRetryDependencies } from '../../src/app/execute-retry/execute-retry-dependencies'
-import type { CommandSpec } from '../../src/domain/command'
 import type { ExecutionResult } from '../../src/app/execute-retry/await-attempt-outcome'
 import * as awaitAttemptOutcomeModule from '../../src/app/execute-retry/await-attempt-outcome'
+import {
+  createCommandSpec,
+  createCompletedCommand,
+} from '../fixtures/execute-retry-fixtures'
 
 vi.mock(
   '../../src/app/execute-retry/await-attempt-outcome',
@@ -22,19 +25,14 @@ describe('executeAttempt', () => {
   })
 
   it('coerces impossible success-with-null-exitCode into an error outcome', async () => {
-    const command: CommandSpec = {
+    const command = createCommandSpec({
       command: 'echo "test"',
-      shell: 'bash',
       timeoutSeconds: undefined,
       terminationGraceSeconds: 5,
-    }
+    })
 
     const dependencies: ExecuteRetryDependencies = {
-      runCommand: vi.fn().mockReturnValue({
-        pid: 1234,
-        completion: Promise.resolve({ exitCode: null, stdout: '' }),
-        isRunning: () => false,
-      }),
+      runCommand: vi.fn().mockReturnValue(createCompletedCommand(null, '')),
       delay: vi.fn(),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
     }

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import {
-  executeRetry,
-} from '../../src/app/execute-retry'
+import { executeRetry } from '../../src/app/execute-retry'
 import {
   createExecuteRetryRequest,
   createCompletedCommand,
@@ -99,11 +97,14 @@ describe('executeRetry', () => {
       isRunning: () => true,
     })
 
-    const resultPromise = executeRetry(createExecuteRetryRequest({ maxAttempts: 1 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree,
-    })
+    const resultPromise = executeRetry(
+      createExecuteRetryRequest({ maxAttempts: 1 }),
+      {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree,
+      },
+    )
 
     const signalCall = processOnceSpy.mock.calls.find(
       (call) => call[0] === signal,
@@ -176,7 +177,9 @@ describe('executeRetry', () => {
       .mockReturnValueOnce(createCompletedCommand(3))
 
     const result = await executeRetry(
-      createExecuteRetryRequest({ policy: { retryOnExitCodes: new Set([2, 7]) } }),
+      createExecuteRetryRequest({
+        policy: { retryOnExitCodes: new Set([2, 7]) },
+      }),
       {
         runCommand,
         delay: vi.fn().mockReturnValue(createNeverDelay()),
@@ -235,11 +238,14 @@ describe('executeRetry', () => {
       throw new Error('spawn failed')
     })
 
-    const result = await executeRetry(createExecuteRetryRequest({ maxAttempts: 2 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
-    })
+    const result = await executeRetry(
+      createExecuteRetryRequest({ maxAttempts: 2 }),
+      {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+      },
+    )
 
     expect(result).toEqual({
       attempt: 2,
@@ -258,11 +264,14 @@ describe('executeRetry', () => {
       isRunning: () => false,
     })
 
-    const result = await executeRetry(createExecuteRetryRequest({ maxAttempts: 2 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree: vi.fn().mockResolvedValue(undefined),
-    })
+    const result = await executeRetry(
+      createExecuteRetryRequest({ maxAttempts: 2 }),
+      {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree: vi.fn().mockResolvedValue(undefined),
+      },
+    )
 
     expect(result).toEqual({
       attempt: 2,

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -1,62 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { RunningCommand } from '../../src/adapters/run-shell-command'
 import {
   executeRetry,
-  type ExecuteRetryRequest,
 } from '../../src/app/execute-retry'
-
-interface ExecuteRetryRequestOverrides {
-  maxAttempts?: ExecuteRetryRequest['maxAttempts']
-  command?: Partial<ExecuteRetryRequest['command']>
-  policy?: Partial<ExecuteRetryRequest['policy']>
-  schedule?: Partial<ExecuteRetryRequest['schedule']>
-}
-
-function createRequest(
-  overrides?: ExecuteRetryRequestOverrides,
-): ExecuteRetryRequest {
-  const defaultCommand = {
-    command: 'echo test',
-    shell: 'bash',
-    timeoutSeconds: undefined,
-    terminationGraceSeconds: 1,
-    ...(overrides?.command || {}),
-  }
-
-  const defaultPolicy = {
-    retryOn: 'any' as const,
-    retryOnExitCodes: undefined,
-    ...(overrides?.policy || {}),
-  }
-
-  const defaultSchedule = {
-    retryDelaySeconds: 0,
-    retryDelayScheduleSeconds: [],
-    ...(overrides?.schedule || {}),
-  }
-
-  return {
-    maxAttempts: overrides?.maxAttempts ?? 3,
-    command: defaultCommand,
-    policy: defaultPolicy,
-    schedule: defaultSchedule,
-  }
-}
-
-function completed(exitCode: number | null, stdout = ''): RunningCommand {
-  return {
-    pid: 100,
-    completion: Promise.resolve({ exitCode, stdout }),
-    isRunning: () => false,
-  }
-}
-
-function createNeverDelay() {
-  return {
-    promise: new Promise<void>(() => {}),
-    cancel: vi.fn(),
-  }
-}
+import {
+  createExecuteRetryRequest,
+  createCompletedCommand,
+  createNeverDelay,
+} from '../fixtures/execute-retry-fixtures'
 
 describe('executeRetry', () => {
   it('returns timeout and terminates process tree when timeout wins', async () => {
@@ -81,7 +31,7 @@ describe('executeRetry', () => {
     })
 
     const result = await executeRetry(
-      createRequest({
+      createExecuteRetryRequest({
         maxAttempts: 1,
         command: {
           timeoutSeconds: 5,
@@ -149,7 +99,7 @@ describe('executeRetry', () => {
       isRunning: () => true,
     })
 
-    const resultPromise = executeRetry(createRequest({ maxAttempts: 1 }), {
+    const resultPromise = executeRetry(createExecuteRetryRequest({ maxAttempts: 1 }), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree,
@@ -180,10 +130,10 @@ describe('executeRetry', () => {
   it('stops when one attempt succeeds', async () => {
     const runCommand = vi
       .fn()
-      .mockReturnValueOnce(completed(1, 'first attempt\n'))
-      .mockReturnValueOnce(completed(0, '{"ok":true}'))
+      .mockReturnValueOnce(createCompletedCommand(1, 'first attempt\n'))
+      .mockReturnValueOnce(createCompletedCommand(0, '{"ok":true}'))
 
-    const result = await executeRetry(createRequest(), {
+    const result = await executeRetry(createExecuteRetryRequest(), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
@@ -199,10 +149,10 @@ describe('executeRetry', () => {
   })
 
   it('stops without retry when policy excludes error failures', async () => {
-    const runCommand = vi.fn().mockReturnValue(completed(9))
+    const runCommand = vi.fn().mockReturnValue(createCompletedCommand(9))
 
     const result = await executeRetry(
-      createRequest({ policy: { retryOn: 'timeout' } }),
+      createExecuteRetryRequest({ policy: { retryOn: 'timeout' } }),
       {
         runCommand,
         delay: vi.fn().mockReturnValue(createNeverDelay()),
@@ -222,11 +172,11 @@ describe('executeRetry', () => {
   it('retries only configured exit codes when filter is provided', async () => {
     const runCommand = vi
       .fn()
-      .mockReturnValueOnce(completed(2))
-      .mockReturnValueOnce(completed(3))
+      .mockReturnValueOnce(createCompletedCommand(2))
+      .mockReturnValueOnce(createCompletedCommand(3))
 
     const result = await executeRetry(
-      createRequest({ policy: { retryOnExitCodes: new Set([2, 7]) } }),
+      createExecuteRetryRequest({ policy: { retryOnExitCodes: new Set([2, 7]) } }),
       {
         runCommand,
         delay: vi.fn().mockReturnValue(createNeverDelay()),
@@ -246,9 +196,9 @@ describe('executeRetry', () => {
   it('applies scheduled retry delay values ahead of fixed delay', async () => {
     const runCommand = vi
       .fn()
-      .mockReturnValueOnce(completed(1))
-      .mockReturnValueOnce(completed(2))
-      .mockReturnValueOnce(completed(3))
+      .mockReturnValueOnce(createCompletedCommand(1))
+      .mockReturnValueOnce(createCompletedCommand(2))
+      .mockReturnValueOnce(createCompletedCommand(3))
 
     const delayFn = vi.fn().mockImplementation((ms) => {
       // If ms is not a small sleep, it's likely a timeout or not our expected sleep
@@ -262,7 +212,7 @@ describe('executeRetry', () => {
     })
 
     const result = await executeRetry(
-      createRequest({
+      createExecuteRetryRequest({
         schedule: {
           retryDelaySeconds: 10,
           retryDelayScheduleSeconds: [1, 5],
@@ -285,7 +235,7 @@ describe('executeRetry', () => {
       throw new Error('spawn failed')
     })
 
-    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
+    const result = await executeRetry(createExecuteRetryRequest({ maxAttempts: 2 }), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
@@ -308,7 +258,7 @@ describe('executeRetry', () => {
       isRunning: () => false,
     })
 
-    const result = await executeRetry(createRequest({ maxAttempts: 2 }), {
+    const result = await executeRetry(createExecuteRetryRequest({ maxAttempts: 2 }), {
       runCommand,
       delay: vi.fn().mockReturnValue(createNeverDelay()),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),

--- a/tests/app/terminate-command-on-signal.test.ts
+++ b/tests/app/terminate-command-on-signal.test.ts
@@ -1,34 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { registerCommandTerminationOnSignal } from '../../src/app/execute-retry/terminate-command-on-signal'
-import type { RunningCommand } from '../../src/adapters/run-shell-command'
-
-function createProcessSpies() {
-  let resolveExit!: (code: number) => void
-  const exitDone = new Promise<number>((resolve) => {
-    resolveExit = resolve
-  })
-
-  return {
-    once: vi.spyOn(process, 'once').mockReturnThis(),
-    off: vi.spyOn(process, 'off').mockReturnThis(),
-    exit: vi
-      .spyOn(process, 'exit')
-      .mockImplementation((code?: number | string | null) => {
-        resolveExit(Number(code))
-        return undefined as never
-      }),
-    exitDone,
-  }
-}
-
-function findSignalHandler(
-  calls: ReadonlyArray<ReadonlyArray<unknown>>,
-  signal: 'SIGTERM' | 'SIGINT',
-): (() => void) | undefined {
-  return calls.find((call) => call[0] === signal)?.[1] as
-    | (() => void)
-    | undefined
-}
+import {
+  createProcessSpies,
+  findSignalHandler,
+} from '../fixtures/process-fixtures'
+import { createCompletedCommand } from '../fixtures/execute-retry-fixtures'
 
 describe('registerCommandTerminationOnSignal', () => {
   beforeEach(() => {
@@ -95,11 +71,10 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('terminates process tree and exits with 0 on SIGTERM', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createCompletedCommand(0, '')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
+    runningCommand.pid = 1234
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),
@@ -169,11 +144,10 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('catches non-Error from terminateProcessTree and exits with 0', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createCompletedCommand(0, '')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
+    runningCommand.pid = 1234
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),
@@ -197,11 +171,10 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('terminates process tree and exits with 0 on SIGINT', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createCompletedCommand(0, '')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
+    runningCommand.pid = 1234
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),
@@ -225,11 +198,10 @@ describe('registerCommandTerminationOnSignal', () => {
 
   it('catches terminateProcessTree error and exits with 0', async () => {
     const processSpies = createProcessSpies()
-    const runningCommand: RunningCommand = {
-      pid: 1234,
-      isRunning: () => true,
-      completion: Promise.resolve({ exitCode: 0, stdout: '' }),
-    }
+    const runningCommand = createCompletedCommand(0, '')
+    // override isRunning to match the test intent
+    runningCommand.isRunning = () => true
+    runningCommand.pid = 1234
 
     const params = {
       getRunningCommand: vi.fn().mockReturnValue(runningCommand),

--- a/tests/fixtures/execute-retry-fixtures.ts
+++ b/tests/fixtures/execute-retry-fixtures.ts
@@ -29,7 +29,9 @@ export function createExecuteRetryRequest(
   }
 }
 
-export function createCommandSpec(overrides?: Partial<CommandSpec>): CommandSpec {
+export function createCommandSpec(
+  overrides?: Partial<CommandSpec>,
+): CommandSpec {
   return {
     command: 'echo test',
     shell: 'bash',

--- a/tests/fixtures/execute-retry-fixtures.ts
+++ b/tests/fixtures/execute-retry-fixtures.ts
@@ -1,0 +1,69 @@
+import { vi } from 'vitest'
+import type { ExecuteRetryRequest } from '../../src/app/execute-retry'
+import type { RunningCommand } from '../../src/adapters/run-shell-command'
+import type { CommandSpec } from '../../src/domain/command'
+
+export interface ExecuteRetryRequestOverrides {
+  maxAttempts?: ExecuteRetryRequest['maxAttempts']
+  command?: Partial<ExecuteRetryRequest['command']>
+  policy?: Partial<ExecuteRetryRequest['policy']>
+  schedule?: Partial<ExecuteRetryRequest['schedule']>
+}
+
+export function createExecuteRetryRequest(
+  overrides?: ExecuteRetryRequestOverrides,
+): ExecuteRetryRequest {
+  return {
+    maxAttempts: overrides?.maxAttempts ?? 3,
+    command: createCommandSpec(overrides?.command),
+    policy: {
+      retryOn: 'any' as const,
+      retryOnExitCodes: undefined,
+      ...(overrides?.policy || {}),
+    },
+    schedule: {
+      retryDelaySeconds: 0,
+      retryDelayScheduleSeconds: [],
+      ...(overrides?.schedule || {}),
+    },
+  }
+}
+
+export function createCommandSpec(overrides?: Partial<CommandSpec>): CommandSpec {
+  return {
+    command: 'echo test',
+    shell: 'bash',
+    timeoutSeconds: undefined,
+    terminationGraceSeconds: 1,
+    ...(overrides || {}),
+  }
+}
+
+export function createCompletedCommand(
+  exitCode: number | null,
+  stdout = '',
+): RunningCommand {
+  return {
+    pid: 100,
+    completion: Promise.resolve({ exitCode, stdout }),
+    isRunning: () => false,
+  }
+}
+
+export function createRunningCommand(
+  pid = 1234,
+  completionPromise?: Promise<{ exitCode: number | null; stdout: string }>,
+): RunningCommand {
+  return {
+    pid,
+    completion: completionPromise || new Promise(() => {}),
+    isRunning: () => true,
+  }
+}
+
+export function createNeverDelay() {
+  return {
+    promise: new Promise<void>(() => {}),
+    cancel: vi.fn(),
+  }
+}

--- a/tests/fixtures/process-fixtures.ts
+++ b/tests/fixtures/process-fixtures.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest'
+
+export function createProcessSpies() {
+  let resolveExit!: (code: number) => void
+  const exitDone = new Promise<number>((resolve) => {
+    resolveExit = resolve
+  })
+
+  return {
+    once: vi.spyOn(process, 'once').mockReturnThis(),
+    off: vi.spyOn(process, 'off').mockReturnThis(),
+    exit: vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code?: number | string | null) => {
+        resolveExit(Number(code))
+        return undefined as never
+      }),
+    exitDone,
+  }
+}
+
+export function findSignalHandler(
+  calls: ReadonlyArray<ReadonlyArray<unknown>>,
+  signal: 'SIGTERM' | 'SIGINT',
+): (() => void) | undefined {
+  return calls.find((call) => call[0] === signal)?.[1] as
+    | (() => void)
+    | undefined
+}


### PR DESCRIPTION
- Created `tests/fixtures/execute-retry-fixtures.ts` with test setup factories (`createExecuteRetryRequest`, `createCompletedCommand`, `createNeverDelay`, `createCommandSpec`, `createRunningCommand`).
- Created `tests/fixtures/process-fixtures.ts` with process mocking utilities (`createProcessSpies`, `findSignalHandler`).
- Refactored `tests/app/execute-retry.test.ts` to use shared execute-retry fixtures.
- Refactored `tests/app/await-attempt-outcome.test.ts` to replace inline initializations with fixtures.
- Refactored `tests/app/execute-attempt.test.ts` to use shared test fixtures.
- Refactored `tests/app/terminate-command-on-signal.test.ts` to use shared process-fixtures.
- Fixed an unused import linter warning in `await-attempt-outcome.test.ts`.
- Ensured all tests continue to pass to prevent any regression.

---
*PR created automatically by Jules for task [6376332691116181311](https://jules.google.com/task/6376332691116181311) started by @akitorahayashi*