### PR TITLE
Refactor multi-concern tests into single-concern tests

### DIFF
--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -39,48 +39,25 @@ describe('readInputs', () => {
     })
   })
 
-  it('parses all optional fields', () => {
+  it.each([
+    { field: 'shell', value: '/bin/bash', expectedProperty: 'shell', expectedValue: '/bin/bash' },
+    { field: 'timeout_seconds', value: '15', expectedProperty: 'timeoutSeconds', expectedValue: 15 },
+    { field: 'retry_delay_seconds', value: '3', expectedProperty: 'retryDelaySeconds', expectedValue: 3 },
+    { field: 'retry_delay_schedule_seconds', value: '1,2,5', expectedProperty: 'retryDelayScheduleSeconds', expectedValue: [1, 2, 5] },
+    { field: 'retry_on', value: 'error', expectedProperty: 'retryOn', expectedValue: 'error' },
+    { field: 'retry_on_exit_codes', value: '1,2,9', expectedProperty: 'retryOnExitCodes', expectedValue: new Set([1, 2, 9]) },
+    { field: 'continue_on_error', value: 'yes', expectedProperty: 'continueOnError', expectedValue: true },
+    { field: 'termination_grace_seconds', value: '2', expectedProperty: 'terminationGraceSeconds', expectedValue: 2 },
+  ])('parses optional field $field', ({ field, value, expectedProperty, expectedValue }) => {
     mockedGetInput.mockImplementation((name: string) => {
-      switch (name) {
-        case 'command':
-          return 'npm run check'
-        case 'max_attempts':
-          return '5'
-        case 'shell':
-          return '/bin/bash'
-        case 'timeout_seconds':
-          return '15'
-        case 'retry_delay_seconds':
-          return '3'
-        case 'retry_delay_schedule_seconds':
-          return '1,2,5'
-        case 'retry_on':
-          return 'error'
-        case 'retry_on_exit_codes':
-          return '1,2,9'
-        case 'continue_on_error':
-          return 'yes'
-        case 'termination_grace_seconds':
-          return '2'
-        default:
-          return ''
-      }
+      if (name === 'command') return 'npm run check'
+      if (name === 'max_attempts') return '5'
+      if (name === field) return value
+      return ''
     })
 
     const result = readInputs()
-    expect(result.retryOnExitCodes).toEqual(new Set([1, 2, 9]))
-    expect(result).toEqual({
-      command: 'npm run check',
-      maxAttempts: 5,
-      shell: '/bin/bash',
-      timeoutSeconds: 15,
-      retryDelaySeconds: 3,
-      retryDelayScheduleSeconds: [1, 2, 5],
-      retryOn: 'error',
-      retryOnExitCodes: new Set([1, 2, 9]),
-      continueOnError: true,
-      terminationGraceSeconds: 2,
-    })
+    expect(result[expectedProperty as keyof ReturnType<typeof readInputs>]).toEqual(expectedValue)
   })
 
   it('throws when required command is missing', () => {
@@ -128,56 +105,21 @@ describe('readInputs', () => {
     expect(() => readInputs()).toThrow("Input 'max_attempts' must be >= 1.")
   })
 
-  it('throws when numeric value is not an integer', () => {
+  it.each([
+    { field: 'max_attempts', value: '3.5' },
+    { field: 'timeout_seconds', value: '10.2' },
+    { field: 'timeout_seconds', value: 'abc' },
+    { field: 'retry_delay_seconds', value: '1.5' },
+  ])('throws when numeric value $field is not an integer', ({ field, value }) => {
     mockedGetInput.mockImplementation((name: string) => {
-      switch (name) {
-        case 'command':
-          return 'echo ok'
-        case 'max_attempts':
-          return '3.5'
-        case 'timeout_seconds':
-          return '10.2'
-        default:
-          return ''
-      }
+      if (name === 'command') return 'echo ok'
+      if (name === 'max_attempts' && field !== 'max_attempts') return '3'
+      if (name === field) return value
+      return ''
     })
 
     expect(() => readInputs()).toThrow(
-      "Input 'max_attempts' must be an integer.",
-    )
-
-    mockedGetInput.mockImplementation((name: string) => {
-      switch (name) {
-        case 'command':
-          return 'echo ok'
-        case 'max_attempts':
-          return '3'
-        case 'timeout_seconds':
-          return 'abc'
-        default:
-          return ''
-      }
-    })
-
-    expect(() => readInputs()).toThrow(
-      "Input 'timeout_seconds' must be an integer.",
-    )
-
-    mockedGetInput.mockImplementation((name: string) => {
-      switch (name) {
-        case 'command':
-          return 'echo ok'
-        case 'max_attempts':
-          return '3'
-        case 'retry_delay_seconds':
-          return '1.5'
-        default:
-          return ''
-      }
-    })
-
-    expect(() => readInputs()).toThrow(
-      "Input 'retry_delay_seconds' must be an integer.",
+      `Input '${field}' must be an integer.`,
     )
   })
 

--- a/tests/action/read-inputs.test.ts
+++ b/tests/action/read-inputs.test.ts
@@ -40,15 +40,60 @@ describe('readInputs', () => {
   })
 
   it.each([
-    { field: 'shell', value: '/bin/bash', expectedProperty: 'shell', expectedValue: '/bin/bash' },
-    { field: 'timeout_seconds', value: '15', expectedProperty: 'timeoutSeconds', expectedValue: 15 },
-    { field: 'retry_delay_seconds', value: '3', expectedProperty: 'retryDelaySeconds', expectedValue: 3 },
-    { field: 'retry_delay_schedule_seconds', value: '1,2,5', expectedProperty: 'retryDelayScheduleSeconds', expectedValue: [1, 2, 5] },
-    { field: 'retry_on', value: 'error', expectedProperty: 'retryOn', expectedValue: 'error' },
-    { field: 'retry_on_exit_codes', value: '1,2,9', expectedProperty: 'retryOnExitCodes', expectedValue: new Set([1, 2, 9]) },
-    { field: 'continue_on_error', value: 'yes', expectedProperty: 'continueOnError', expectedValue: true },
-    { field: 'termination_grace_seconds', value: '2', expectedProperty: 'terminationGraceSeconds', expectedValue: 2 },
-  ])('parses optional field $field', ({ field, value, expectedProperty, expectedValue }) => {
+    {
+      field: 'shell',
+      value: '/bin/bash',
+      expectedProperty: 'shell',
+      expectedValue: '/bin/bash',
+    },
+    {
+      field: 'timeout_seconds',
+      value: '15',
+      expectedProperty: 'timeoutSeconds',
+      expectedValue: 15,
+    },
+    {
+      field: 'retry_delay_seconds',
+      value: '3',
+      expectedProperty: 'retryDelaySeconds',
+      expectedValue: 3,
+    },
+    {
+      field: 'retry_delay_schedule_seconds',
+      value: '1,2,5',
+      expectedProperty: 'retryDelayScheduleSeconds',
+      expectedValue: [1, 2, 5],
+    },
+    {
+      field: 'retry_on',
+      value: 'error',
+      expectedProperty: 'retryOn',
+      expectedValue: 'error',
+    },
+    {
+      field: 'retry_on_exit_codes',
+      value: '1,2,9',
+      expectedProperty: 'retryOnExitCodes',
+      expectedValue: new Set([1, 2, 9]),
+    },
+    {
+      field: 'continue_on_error',
+      value: 'yes',
+      expectedProperty: 'continueOnError',
+      expectedValue: true,
+    },
+    {
+      field: 'termination_grace_seconds',
+      value: '2',
+      expectedProperty: 'terminationGraceSeconds',
+      expectedValue: 2,
+    },
+  ])('parses optional field $field', ({
+    field,
+    value,
+    expectedProperty,
+    expectedValue,
+  }) => {
     mockedGetInput.mockImplementation((name: string) => {
       if (name === 'command') return 'npm run check'
       if (name === 'max_attempts') return '5'
@@ -57,7 +102,9 @@ describe('readInputs', () => {
     })
 
     const result = readInputs()
-    expect(result[expectedProperty as keyof ReturnType<typeof readInputs>]).toEqual(expectedValue)
+    expect(
+      result[expectedProperty as keyof ReturnType<typeof readInputs>],
+    ).toEqual(expectedValue)
   })
 
   it('throws when required command is missing', () => {
@@ -110,7 +157,10 @@ describe('readInputs', () => {
     { field: 'timeout_seconds', value: '10.2' },
     { field: 'timeout_seconds', value: 'abc' },
     { field: 'retry_delay_seconds', value: '1.5' },
-  ])('throws when numeric value $field is not an integer', ({ field, value }) => {
+  ])('throws when numeric value $field is not an integer', ({
+    field,
+    value,
+  }) => {
     mockedGetInput.mockImplementation((name: string) => {
       if (name === 'command') return 'echo ok'
       if (name === 'max_attempts' && field !== 'max_attempts') return '3'
@@ -118,9 +168,7 @@ describe('readInputs', () => {
       return ''
     })
 
-    expect(() => readInputs()).toThrow(
-      `Input '${field}' must be an integer.`,
-    )
+    expect(() => readInputs()).toThrow(`Input '${field}' must be an integer.`)
   })
 
   it.each([

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -107,74 +107,110 @@ describe('executeRetry', () => {
     })
   })
 
-  it.each([
-    { signal: 'SIGTERM' as const, pid: 200 },
-    { signal: 'SIGINT' as const, pid: 201 },
-  ])('interrupts running command and terminates process tree on $signal', async ({
-    signal,
-    pid,
-  }) => {
-    const processOnceSpy = vi
-      .spyOn(process, 'once')
-      .mockImplementation(() => process)
-    const processOffSpy = vi
-      .spyOn(process, 'off')
-      .mockImplementation(() => process)
-    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+  describe('interrupts running command and terminates process tree on signal', () => {
+    async function setupSignalTest(signal: 'SIGTERM' | 'SIGINT', pid: number) {
+      const processOnceSpy = vi
+        .spyOn(process, 'once')
+        .mockImplementation(() => process)
+      const processOffSpy = vi
+        .spyOn(process, 'off')
+        .mockImplementation(() => process)
+      vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
 
-    let resolveCompletion!: (value: {
-      exitCode: number | null
-      stdout: string
-    }) => void
-    const completionPromise = new Promise<{
-      exitCode: number | null
-      stdout: string
-    }>((resolve) => {
-      resolveCompletion = resolve
+      let resolveCompletion!: (value: {
+        exitCode: number | null
+        stdout: string
+      }) => void
+      const completionPromise = new Promise<{
+        exitCode: number | null
+        stdout: string
+      }>((resolve) => {
+        resolveCompletion = resolve
+      })
+
+      let resolveTerminate!: () => void
+      const terminatePromise = new Promise<void>((resolve) => {
+        resolveTerminate = resolve
+      })
+
+      const terminateProcessTree = vi.fn().mockImplementation(() => {
+        resolveTerminate()
+        return Promise.resolve()
+      })
+
+      const runCommand = vi.fn().mockReturnValue({
+        pid,
+        completion: completionPromise,
+        isRunning: () => true,
+      })
+
+      const resultPromise = executeRetry(createRequest({ maxAttempts: 1 }), {
+        runCommand,
+        delay: vi.fn().mockReturnValue(createNeverDelay()),
+        terminateProcessTree,
+      })
+
+      const signalCall = processOnceSpy.mock.calls.find(
+        (call) => call[0] === signal,
+      )
+      const signalHandler = signalCall?.[1] as () => void
+
+      return {
+        processOffSpy,
+        resolveCompletion,
+        terminatePromise,
+        terminateProcessTree,
+        resultPromise,
+        signalHandler,
+      }
+    }
+
+    it.each([
+      { signal: 'SIGTERM' as const, pid: 200 },
+      { signal: 'SIGINT' as const, pid: 201 },
+    ])('terminates process tree on $signal', async ({ signal, pid }) => {
+      const {
+        terminatePromise,
+        terminateProcessTree,
+        signalHandler,
+        resolveCompletion,
+        resultPromise,
+      } = await setupSignalTest(signal, pid)
+
+      expect(signalHandler).toBeDefined()
+      signalHandler()
+
+      await terminatePromise
+      expect(terminateProcessTree).toHaveBeenCalledWith(pid, 1)
+
+      resolveCompletion({ exitCode: null, stdout: '' })
+      await resultPromise
     })
 
-    let resolveTerminate!: () => void
-    const terminatePromise = new Promise<void>((resolve) => {
-      resolveTerminate = resolve
+    it.each([
+      { signal: 'SIGTERM' as const, pid: 200 },
+      { signal: 'SIGINT' as const, pid: 201 },
+    ])('removes signal handlers after interrupt by $signal', async ({ signal, pid }) => {
+      const {
+        processOffSpy,
+        signalHandler,
+        resolveCompletion,
+        resultPromise,
+      } = await setupSignalTest(signal, pid)
+
+      expect(signalHandler).toBeDefined()
+      signalHandler()
+
+      resolveCompletion({ exitCode: null, stdout: '' })
+      await resultPromise
+
+      const otherSignal = signal === 'SIGTERM' ? 'SIGINT' : 'SIGTERM'
+      expect(processOffSpy).toHaveBeenCalledWith(signal, signalHandler)
+      expect(processOffSpy).toHaveBeenCalledWith(
+        otherSignal,
+        expect.any(Function),
+      )
     })
-
-    const terminateProcessTree = vi.fn().mockImplementation(() => {
-      resolveTerminate()
-      return Promise.resolve()
-    })
-
-    const runCommand = vi.fn().mockReturnValue({
-      pid,
-      completion: completionPromise,
-      isRunning: () => true,
-    })
-
-    const resultPromise = executeRetry(createRequest({ maxAttempts: 1 }), {
-      runCommand,
-      delay: vi.fn().mockReturnValue(createNeverDelay()),
-      terminateProcessTree,
-    })
-
-    const signalCall = processOnceSpy.mock.calls.find(
-      (call) => call[0] === signal,
-    )
-    expect(signalCall).toBeDefined()
-    const signalHandler = signalCall?.[1] as () => void
-
-    signalHandler()
-
-    await terminatePromise
-    expect(terminateProcessTree).toHaveBeenCalledWith(pid, 1)
-
-    resolveCompletion({ exitCode: null, stdout: '' })
-    await resultPromise
-
-    const otherSignal = signal === 'SIGTERM' ? 'SIGINT' : 'SIGTERM'
-    expect(processOffSpy).toHaveBeenCalledWith(signal, signalHandler)
-    expect(processOffSpy).toHaveBeenCalledWith(
-      otherSignal,
-      expect.any(Function),
-    )
   })
 
   it('stops when one attempt succeeds', async () => {

--- a/tests/app/execute-retry.test.ts
+++ b/tests/app/execute-retry.test.ts
@@ -190,13 +190,12 @@ describe('executeRetry', () => {
     it.each([
       { signal: 'SIGTERM' as const, pid: 200 },
       { signal: 'SIGINT' as const, pid: 201 },
-    ])('removes signal handlers after interrupt by $signal', async ({ signal, pid }) => {
-      const {
-        processOffSpy,
-        signalHandler,
-        resolveCompletion,
-        resultPromise,
-      } = await setupSignalTest(signal, pid)
+    ])('removes signal handlers after interrupt by $signal', async ({
+      signal,
+      pid,
+    }) => {
+      const { processOffSpy, signalHandler, resolveCompletion, resultPromise } =
+        await setupSignalTest(signal, pid)
 
       expect(signalHandler).toBeDefined()
       signalHandler()


### PR DESCRIPTION
This PR splits multi-concern tests into smaller, more focused tests that each verify a single externally visible behavior to improve diagnostics when they fail.

Modifications:
- `tests/app/execute-retry.test.ts`: Split the test `interrupts running command and terminates process tree on $signal` into two independent tests using a common setup helper function `setupSignalTest`. One test validates the process termination tree is called and the other checks that signal handlers are removed.
- `tests/action/read-inputs.test.ts`: Replaced the single test `parses all optional fields` with an `it.each` block to independently validate parsing for each optional field (`shell`, `timeout_seconds`, `retry_delay_seconds`, etc). Replaced the sequential assertions in `throws when numeric value is not an integer` with an `it.each` block to independently test the failure conditions.

No business logic or execution pathways were changed in the app codebase, strictly test refactoring. All tests pass successfully.

---
*PR created automatically by Jules for task [10622741903875321667](https://jules.google.com/task/10622741903875321667) started by @akitorahayashi*