### PR TITLE
Refactor: Unify execution outcome representations to AttemptResult

### DIFF
--- a/src/app/execute-retry/await-attempt-outcome.ts
+++ b/src/app/execute-retry/await-attempt-outcome.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import type { RunningCommand } from '../../adapters/run-shell-command'
 import type { CommandSpec } from '../../domain/command'
-import type { AttemptOutcome } from '../../domain/policy'
+import type { AttemptOutcome, AttemptResult } from '../../domain/result'
 import { formatExitCode } from './format-exit-code'
 
 interface AwaitAttemptOutcomeDependencies {
@@ -12,11 +12,6 @@ interface AwaitAttemptOutcomeDependencies {
   terminateProcessTree: (pid: number, graceSeconds: number) => Promise<void>
 }
 
-export type ExecutionResult =
-  | { outcome: 'success'; exitCode: number; stdout: string }
-  | { outcome: 'error'; exitCode: number | null; stdout: string }
-  | { outcome: 'timeout'; exitCode: null; stdout: string }
-
 type RaceOutcome =
   | { type: 'completion'; exitCode: number | null; stdout: string }
   | { type: 'timeout' }
@@ -26,7 +21,7 @@ export async function awaitAttemptOutcome(
   attempt: number,
   runningCommand: RunningCommand,
   dependencies: AwaitAttemptOutcomeDependencies,
-): Promise<ExecutionResult> {
+): Promise<AttemptResult> {
   const completionPromise: Promise<RaceOutcome> =
     runningCommand.completion.then((completion) => ({
       type: 'completion',
@@ -41,12 +36,14 @@ export async function awaitAttemptOutcome(
     }
     if (completion.exitCode === 0) {
       return {
+        attempt,
         outcome: 'success',
         exitCode: completion.exitCode,
         stdout: completion.stdout,
       }
     }
     return {
+      attempt,
       outcome: 'error',
       exitCode: completion.exitCode,
       stdout: completion.stdout,
@@ -64,12 +61,14 @@ export async function awaitAttemptOutcome(
     if (result.type === 'completion') {
       if (result.exitCode === 0) {
         return {
+          attempt,
           outcome: 'success',
           exitCode: result.exitCode,
           stdout: result.stdout,
         }
       }
       return {
+        attempt,
         outcome: 'error',
         exitCode: result.exitCode,
         stdout: result.stdout,
@@ -105,6 +104,7 @@ export async function awaitAttemptOutcome(
           `Process pid=${runningCommand.pid} failed to complete after termination. Returning safe outcome.`,
         )
         return {
+          attempt,
           outcome: 'timeout',
           exitCode: null,
           stdout: '',
@@ -114,6 +114,7 @@ export async function awaitAttemptOutcome(
       // For timeout outcomes, the exit code from a terminated process isn't
       // representative of the command's execution, so we always use null.
       return {
+        attempt,
         outcome: 'timeout',
         exitCode: null,
         stdout: finalCompletion.stdout,

--- a/src/app/execute-retry/execute-attempt.ts
+++ b/src/app/execute-retry/execute-attempt.ts
@@ -40,36 +40,7 @@ export async function executeAttempt(
 
       logAttemptCompletion(attempt, result.outcome, result.exitCode)
 
-      if (result.outcome === 'success') {
-        if (result.exitCode === null) {
-          throw new Error(
-            'Successful attempt must include a numeric exit code.',
-          )
-        }
-
-        return {
-          attempt,
-          outcome: 'success',
-          exitCode: result.exitCode,
-          stdout: result.stdout,
-        }
-      }
-
-      if (result.outcome === 'timeout') {
-        return {
-          attempt,
-          outcome: 'timeout',
-          exitCode: null,
-          stdout: result.stdout,
-        }
-      }
-
-      return {
-        attempt,
-        outcome: 'error',
-        exitCode: result.exitCode,
-        stdout: result.stdout,
-      }
+      return result
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error)

--- a/src/domain/policy.ts
+++ b/src/domain/policy.ts
@@ -1,4 +1,5 @@
-export type AttemptOutcome = 'success' | 'error' | 'timeout'
+import type { AttemptOutcome } from './result'
+
 export type RetryOn = 'any' | 'error' | 'timeout'
 
 export interface RetryPolicy {

--- a/src/domain/result.ts
+++ b/src/domain/result.ts
@@ -1,3 +1,5 @@
+export type AttemptOutcome = 'success' | 'error' | 'timeout'
+
 export type AttemptResult =
   | {
       attempt: number

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -35,7 +35,12 @@ describe('awaitAttemptOutcome', () => {
       runningCommand,
       dependencies,
     )
-    expect(result).toEqual({ attempt: 1, outcome: 'success', exitCode: 0, stdout: 'ok\n' })
+    expect(result).toEqual({
+      attempt: 1,
+      outcome: 'success',
+      exitCode: 0,
+      stdout: 'ok\n',
+    })
     expect(dependencies.delay).not.toHaveBeenCalled()
   })
 
@@ -411,7 +416,12 @@ describe('awaitAttemptOutcome', () => {
 
     const result = await resultPromise
 
-    expect(result).toEqual({ attempt: 1, outcome: 'timeout', exitCode: null, stdout: '' })
+    expect(result).toEqual({
+      attempt: 1,
+      outcome: 'timeout',
+      exitCode: null,
+      stdout: '',
+    })
     resolveCompletion({ exitCode: 1, stdout: '' })
   })
 })

--- a/tests/app/await-attempt-outcome.test.ts
+++ b/tests/app/await-attempt-outcome.test.ts
@@ -35,7 +35,7 @@ describe('awaitAttemptOutcome', () => {
       runningCommand,
       dependencies,
     )
-    expect(result).toEqual({ outcome: 'success', exitCode: 0, stdout: 'ok\n' })
+    expect(result).toEqual({ attempt: 1, outcome: 'success', exitCode: 0, stdout: 'ok\n' })
     expect(dependencies.delay).not.toHaveBeenCalled()
   })
 
@@ -99,6 +99,7 @@ describe('awaitAttemptOutcome', () => {
       dependencies,
     )
     expect(result).toEqual({
+      attempt: 1,
       outcome: 'error',
       exitCode: 1,
       stdout: 'failed\n',
@@ -147,6 +148,7 @@ describe('awaitAttemptOutcome', () => {
     const result = await resultPromise
 
     expect(result).toEqual({
+      attempt: 1,
       outcome: 'success',
       exitCode: 0,
       stdout: '{"ok":true}',
@@ -235,6 +237,7 @@ describe('awaitAttemptOutcome', () => {
     const result = await attemptPromise
 
     expect(result).toEqual({
+      attempt: 1,
       outcome: 'timeout',
       exitCode: null,
       stdout: 'partial\n',
@@ -408,7 +411,7 @@ describe('awaitAttemptOutcome', () => {
 
     const result = await resultPromise
 
-    expect(result).toEqual({ outcome: 'timeout', exitCode: null, stdout: '' })
+    expect(result).toEqual({ attempt: 1, outcome: 'timeout', exitCode: null, stdout: '' })
     resolveCompletion({ exitCode: 1, stdout: '' })
   })
 })

--- a/tests/app/execute-attempt.test.ts
+++ b/tests/app/execute-attempt.test.ts
@@ -46,8 +46,12 @@ describe('executeAttempt', () => {
       stdout: 'ok\n',
     }
 
-    vi.mocked(awaitAttemptOutcomeModule.awaitAttemptOutcome).mockResolvedValue(expectedResult)
+    vi.mocked(awaitAttemptOutcomeModule.awaitAttemptOutcome).mockResolvedValue(
+      expectedResult,
+    )
 
-    await expect(executeAttempt(command, 1, dependencies)).resolves.toEqual(expectedResult)
+    await expect(executeAttempt(command, 1, dependencies)).resolves.toEqual(
+      expectedResult,
+    )
   })
 })

--- a/tests/app/execute-attempt.test.ts
+++ b/tests/app/execute-attempt.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { executeAttempt } from '../../src/app/execute-retry/execute-attempt'
 import type { ExecuteRetryDependencies } from '../../src/app/execute-retry/execute-retry-dependencies'
 import type { CommandSpec } from '../../src/domain/command'
-import type { ExecutionResult } from '../../src/app/execute-retry/await-attempt-outcome'
+import type { AttemptResult } from '../../src/domain/result'
 import * as awaitAttemptOutcomeModule from '../../src/app/execute-retry/await-attempt-outcome'
 
 vi.mock(
@@ -21,7 +21,7 @@ describe('executeAttempt', () => {
     vi.clearAllMocks()
   })
 
-  it('coerces impossible success-with-null-exitCode into an error outcome', async () => {
+  it('returns the result of awaitAttemptOutcome directly', async () => {
     const command: CommandSpec = {
       command: 'echo "test"',
       shell: 'bash',
@@ -32,24 +32,22 @@ describe('executeAttempt', () => {
     const dependencies: ExecuteRetryDependencies = {
       runCommand: vi.fn().mockReturnValue({
         pid: 1234,
-        completion: Promise.resolve({ exitCode: null, stdout: '' }),
+        completion: Promise.resolve({ exitCode: 0, stdout: 'ok\n' }),
         isRunning: () => false,
       }),
       delay: vi.fn(),
       terminateProcessTree: vi.fn().mockResolvedValue(undefined),
     }
 
-    vi.mocked(awaitAttemptOutcomeModule.awaitAttemptOutcome).mockResolvedValue({
-      outcome: 'success',
-      exitCode: null,
-      stdout: '',
-    } as unknown as ExecutionResult)
-
-    await expect(executeAttempt(command, 1, dependencies)).resolves.toEqual({
+    const expectedResult: AttemptResult = {
       attempt: 1,
-      outcome: 'error',
-      exitCode: null,
-      stdout: '',
-    })
+      outcome: 'success',
+      exitCode: 0,
+      stdout: 'ok\n',
+    }
+
+    vi.mocked(awaitAttemptOutcomeModule.awaitAttemptOutcome).mockResolvedValue(expectedResult)
+
+    await expect(executeAttempt(command, 1, dependencies)).resolves.toEqual(expectedResult)
   })
 })


### PR DESCRIPTION
Refactored the result models to eliminate redundancy and unify `AttemptResult` across the boundaries, addressing the overlap between `ExecutionResult` and `AttemptOutcome`.

### Changes made
1. Relocated `AttemptOutcome` from `src/domain/policy.ts` to `src/domain/result.ts` and updated dependencies.
2. Eliminated the `ExecutionResult` type from `src/app/execute-retry/await-attempt-outcome.ts`.
3. Updated `awaitAttemptOutcome` to construct and return an `AttemptResult` by directly injecting the attempt number.
4. Simplified `executeAttempt` in `src/app/execute-retry/execute-attempt.ts` to return the `AttemptResult` directly without re-mapping the result properties.
5. Updated corresponding tests in `tests/app/await-attempt-outcome.test.ts` and `tests/app/execute-attempt.test.ts`.

---
*PR created automatically by Jules for task [7725906072601356377](https://jules.google.com/task/7725906072601356377) started by @akitorahayashi*